### PR TITLE
MonadChronicle implementation

### DIFF
--- a/core/src/main/scala/cats/mtl/MonadChronicle.scala
+++ b/core/src/main/scala/cats/mtl/MonadChronicle.scala
@@ -1,0 +1,29 @@
+package cats
+package mtl
+
+import cats.data.Ior
+
+trait MonadChronicle[F[_], E] extends Serializable {
+  val monad: Monad[F]
+
+  def dictate(c: E): F[Unit]
+
+  def disclose[A](c: E)(implicit M: Monoid[A]): F[A]
+
+  def confess[A](c: E): F[A]
+
+  def memento[A](ma: F[A]): F[Either[E, A]]
+
+  def absolve[A](a: A, ma: F[A]): F[A]
+
+  def condemn[A](ma: F[A]): F[A]
+
+  def retcon[A](cc: E => E, ma: F[A]): F[A]
+
+  def chronicle[A](ior: E Ior A): F[A]
+}
+
+object MonadChronicle {
+  def apply[F[_], E](implicit monadChronicle: MonadChronicle[F, E]): MonadChronicle[F, E] =
+    monadChronicle
+}

--- a/core/src/main/scala/cats/mtl/MonadChronicle.scala
+++ b/core/src/main/scala/cats/mtl/MonadChronicle.scala
@@ -36,17 +36,6 @@ object MonadChronicle {
   def materialize[F[_], E, A](fa: F[A])(implicit ev: MonadChronicle[F, E]): F[E Ior A] =
     ev.materialize(fa)
 
-  def memento[F[_], E, A](fa: F[A])(implicit ev: MonadChronicle[F, E]): F[Either[E, A]] =
-    ev.memento(fa)
-
-  def absolve[F[_], E, A](a: => A, fa: F[A])(implicit ev: MonadChronicle[F, E]): F[A] =
-    ev.absolve(a, fa)
-
-  def condemn[F[_], E, A](fa: F[A])(implicit ev: MonadChronicle[F, E]): F[A] = ev.condemn(fa)
-
-  def retcon[F[_], E, A](cc: E => E, fa: F[A])(implicit ev: MonadChronicle[F, E]): F[A] =
-    ev.retcon(cc, fa)
-
   def chronicle[F[_], E, A](ior: E Ior A)(implicit ev: MonadChronicle[F, E]): F[A] =
     ev.chronicle(ior)
 
@@ -58,8 +47,8 @@ trait DefaultMonadChronicle[F[_], E] extends MonadChronicle[F, E] {
   override def disclose[A](c: E)(implicit M: Monoid[A]): F[A] = monad.as(dictate(c), M.empty)
 
   override def memento[A](fa: F[A]): F[Either[E, A]] = monad.flatMap(materialize(fa)) {
-    case Ior.Left(e) => monad.pure(Left(e))
-    case Ior.Right(a) => monad.pure(Right(a))
+    case Ior.Left(e)    => monad.pure(Left(e))
+    case Ior.Right(a)   => monad.pure(Right(a))
     case Ior.Both(e, a) => monad.as(dictate(e), Right(a))
   }
 

--- a/core/src/main/scala/cats/mtl/MonadChronicle.scala
+++ b/core/src/main/scala/cats/mtl/MonadChronicle.scala
@@ -12,18 +12,74 @@ trait MonadChronicle[F[_], E] extends Serializable {
 
   def confess[A](c: E): F[A]
 
-  def memento[A](ma: F[A]): F[Either[E, A]]
+  def materialize[A](fa: F[A]): F[E Ior A]
 
-  def absolve[A](a: A, ma: F[A]): F[A]
+  def memento[A](fa: F[A]): F[Either[E, A]]
 
-  def condemn[A](ma: F[A]): F[A]
+  def absolve[A](a: => A, fa: F[A]): F[A]
 
-  def retcon[A](cc: E => E, ma: F[A]): F[A]
+  def condemn[A](fa: F[A]): F[A]
+
+  def retcon[A](cc: E => E, fa: F[A]): F[A]
 
   def chronicle[A](ior: E Ior A): F[A]
 }
 
 object MonadChronicle {
-  def apply[F[_], E](implicit monadChronicle: MonadChronicle[F, E]): MonadChronicle[F, E] =
-    monadChronicle
+  def dictate[F[_], E](e: E)(implicit ev: MonadChronicle[F, E]): F[Unit] = ev.dictate(e)
+
+  def disclose[F[_], A, E](c: E)(implicit ev: MonadChronicle[F, E], m: Monoid[A]): F[A] =
+    ev.disclose(c)
+
+  def confess[F[_], E, A](c: E)(implicit ev: MonadChronicle[F, E]): F[A] = ev.confess(c)
+
+  def materialize[F[_], E, A](fa: F[A])(implicit ev: MonadChronicle[F, E]): F[E Ior A] =
+    ev.materialize(fa)
+
+  def memento[F[_], E, A](fa: F[A])(implicit ev: MonadChronicle[F, E]): F[Either[E, A]] =
+    ev.memento(fa)
+
+  def absolve[F[_], E, A](a: => A, fa: F[A])(implicit ev: MonadChronicle[F, E]): F[A] =
+    ev.absolve(a, fa)
+
+  def condemn[F[_], E, A](fa: F[A])(implicit ev: MonadChronicle[F, E]): F[A] = ev.condemn(fa)
+
+  def retcon[F[_], E, A](cc: E => E, fa: F[A])(implicit ev: MonadChronicle[F, E]): F[A] =
+    ev.retcon(cc, fa)
+
+  def chronicle[F[_], E, A](ior: E Ior A)(implicit ev: MonadChronicle[F, E]): F[A] =
+    ev.chronicle(ior)
+
+  def apply[F[_], E](implicit ev: MonadChronicle[F, E]): MonadChronicle[F, E] =
+    ev
+}
+
+trait DefaultMonadChronicle[F[_], E] extends MonadChronicle[F, E] {
+  override def disclose[A](c: E)(implicit M: Monoid[A]): F[A] = monad.as(dictate(c), M.empty)
+
+  override def memento[A](fa: F[A]): F[Either[E, A]] = monad.map(materialize(fa))(_.toEither)
+
+  override def absolve[A](a: => A, fa: F[A]): F[A] = monad.map(materialize(fa)) {
+    case Ior.Left(_)     => a
+    case Ior.Right(a0)   => a0
+    case Ior.Both(_, a0) => a0
+  }
+
+  override def condemn[A](fa: F[A]): F[A] = monad.flatMap(materialize(fa)) {
+    case Ior.Left(e)    => confess(e)
+    case Ior.Right(a)   => monad.pure(a)
+    case Ior.Both(e, _) => confess(e)
+  }
+
+  override def retcon[A](cc: E => E, fa: F[A]): F[A] = monad.flatMap(materialize(fa)) {
+    case Ior.Left(e)    => confess(cc(e))
+    case Ior.Right(a)   => monad.pure(a)
+    case Ior.Both(e, a) => monad.as(dictate(e), a)
+  }
+
+  override def chronicle[A](ior: E Ior A): F[A] = ior match {
+    case Ior.Left(e)    => confess(e)
+    case Ior.Right(a)   => monad.pure(a)
+    case Ior.Both(e, a) => monad.as(dictate(e), a)
+  }
 }

--- a/core/src/main/scala/cats/mtl/instances/all.scala
+++ b/core/src/main/scala/cats/mtl/instances/all.scala
@@ -10,4 +10,5 @@ trait AllInstances extends EitherTInstances
   with LocalInstances with StateInstances
   with StateTInstances with WriterTInstances
   with EmptyInstances with ReaderWriterStateTInstances
+  with ChronicleInstances with IorTInstances
 

--- a/core/src/main/scala/cats/mtl/instances/chronicle.scala
+++ b/core/src/main/scala/cats/mtl/instances/chronicle.scala
@@ -1,0 +1,45 @@
+package cats
+package mtl
+package instances
+
+import cats.data.{Ior, IorT}
+import cats.syntax.functor._
+
+trait ChronicleInstances extends ChronicleLowPriorityInstances
+
+trait ChronicleLowPriorityInstances {
+  implicit final def chronicleIorT[F[_], E](implicit S: Semigroup[E],
+                                            F: Monad[F]): MonadChronicle[IorTC[F, E]#l, E] =
+    new DefaultMonadChronicle[IorTC[F, E]#l, E] {
+      override val monad: Monad[IorTC[F, E]#l] = IorT.catsDataMonadErrorForIorT
+
+      override def dictate(c: E): IorT[F, E, Unit] = IorT.bothT[F](c, ())
+
+      override def confess[A](c: E): IorT[F, E, A] = IorT.leftT[F, A](c)
+
+      override def materialize[A](fa: IorT[F, E, A]): IorT[F, E, E Ior A] = IorT[F, E, E Ior A] {
+        fa.value.map {
+          case Ior.Left(e)    => Ior.right(Ior.left(e))
+          case Ior.Right(a)   => Ior.right(Ior.right(a))
+          case Ior.Both(e, a) => Ior.right(Ior.both(e, a))
+        }
+      }
+    }
+
+  implicit final def chronicleIor[E](implicit S: Semigroup[E]): MonadChronicle[IorC[E]#l, E] =
+    new DefaultMonadChronicle[IorC[E]#l, E] {
+      override val monad: Monad[IorC[E]#l] = Ior.catsDataMonadErrorForIor
+
+      override def dictate(c: E): Ior[E, Unit] = Ior.both(c, ())
+
+      override def confess[A](c: E): Ior[E, A] = Ior.left(c)
+
+      override def materialize[A](fa: Ior[E, A]): Ior[E, Ior[E, A]] = fa match {
+        case Ior.Left(e)    => Ior.right(Ior.left(e))
+        case Ior.Right(a)   => Ior.right(Ior.right(a))
+        case Ior.Both(e, a) => Ior.right(Ior.both(e, a))
+      }
+    }
+}
+
+object chronicle extends ChronicleInstances

--- a/core/src/main/scala/cats/mtl/instances/chronicle.scala
+++ b/core/src/main/scala/cats/mtl/instances/chronicle.scala
@@ -3,6 +3,7 @@ package mtl
 package instances
 
 import cats.data.{Ior, IorT}
+import cats.mtl.lifting.MonadLayerControl
 import cats.syntax.functor._
 
 trait ChronicleInstances extends ChronicleLowPriorityInstances {

--- a/core/src/main/scala/cats/mtl/instances/iort.scala
+++ b/core/src/main/scala/cats/mtl/instances/iort.scala
@@ -3,6 +3,7 @@ package mtl
 package instances
 
 import cats.data.{Ior, IorT}
+import cats.mtl.lifting.{FunctorLayerFunctor, MonadLayerControl}
 import cats.syntax.functor._
 
 trait IorTInstances extends IorTInstances1 {

--- a/core/src/main/scala/cats/mtl/instances/iort.scala
+++ b/core/src/main/scala/cats/mtl/instances/iort.scala
@@ -1,0 +1,100 @@
+package cats
+package mtl
+package instances
+
+import cats.data.{Ior, IorT}
+import cats.syntax.functor._
+
+trait IorTInstances extends IorTInstances1 {
+  implicit def iorFunctorLayerFunctor[M[_], A](
+      implicit M: Functor[M]): FunctorLayerFunctor[IorTC[M, A]#l, M] = {
+    new FunctorLayerFunctor[IorTC[M, A]#l, M] {
+      override def layerMapK[B](ma: IorT[M, A, B])(trans: M ~> M): IorT[M, A, B] = ma.mapK(trans)
+
+      override val outerInstance: Functor[IorTC[M, A]#l] = IorT.catsDataFunctorForIorT[M, A](M)
+      override val innerInstance: Functor[M] = M
+
+      override def layer[B](inner: M[B]): IorT[M, A, B] = IorT.right(inner)
+    }
+  }
+}
+
+trait IorTInstances1 extends IorTInstancesLowPriority1 {
+  implicit def iorMonadLayerFunctor[M[_], A](
+      implicit M: Monad[M],
+      S: Semigroup[A]): MonadLayerControl.Aux[IorTC[M, A]#l, M, IorC[A]#l] =
+    new MonadLayerControl[IorTC[M, A]#l, M] {
+      override type State[B] = Ior[A, B]
+
+      override def restore[B](state: Ior[A, B]): IorT[M, A, B] = IorT(M.pure(state))
+      override def layerControl[B](
+          cps: (IorTC[M, A]#l ~> (M of IorC[A]#l)#l) => M[B]): IorT[M, A, B] = {
+        IorT[M, A, B] {
+          cps(new (IorTC[M, A]#l ~> (M of IorC[A]#l)#l) {
+            def apply[X](fa: IorT[M, A, X]): M[Ior[A, X]] = fa.value
+          }).map(b => Ior.right[A, B](b))
+        }
+      }
+
+      override def zero[B](state: Ior[A, B]): Boolean = false
+
+      override def layerMapK[B](ma: IorT[M, A, B])(trans: M ~> M): IorT[M, A, B] = ma.mapK(trans)
+
+      override val outerInstance: Monad[IorTC[M, A]#l] = IorT.catsDataMonadErrorForIorT
+      override val innerInstance: Monad[M] = M
+
+      override def layer[B](inner: M[B]): IorT[M, A, B] = IorT.liftF(inner)
+    }
+}
+
+private[instances] trait IorTInstancesLowPriority1 {
+  final implicit def chronicleIorT[F[_], E](implicit S: Semigroup[E],
+                                            F: Monad[F]): MonadChronicle[IorTC[F, E]#l, E] =
+    new MonadChronicle[IorTC[F, E]#l, E] {
+      override val monad: Monad[IorTC[F, E]#l] = IorT.catsDataMonadErrorForIorT
+
+      override def dictate(c: E): IorT[F, E, Unit] = IorT.left(F.pure(c))
+
+      override def disclose[A](c: E)(implicit M: Monoid[A]): IorT[F, E, A] =
+        IorT.both(F.pure(c), F.pure(M.empty))
+
+      override def confess[A](c: E): IorT[F, E, A] = IorT.left(F.pure(c))
+
+      override def memento[A](ma: IorT[F, E, A]): IorT[F, E, Either[E, A]] =
+        IorT[F, E, Either[E, A]] {
+          F.map(ma.value) {
+            case Ior.Left(e)    => Ior.right(Left(e))
+            case Ior.Right(a)   => Ior.right(Right(a))
+            case Ior.Both(e, a) => Ior.both(e, Right(a))
+          }
+        }
+
+      override def absolve[A](a: A, ma: IorT[F, E, A]): IorT[F, E, A] = IorT[F, E, A] {
+        F.map(ma.value) {
+          case Ior.Left(_)     => Ior.right(a)
+          case Ior.Right(a0)   => Ior.right(a0)
+          case Ior.Both(_, a0) => Ior.right(a0)
+        }
+      }
+
+      override def condemn[A](ma: IorT[F, E, A]): IorT[F, E, A] = IorT[F, E, A] {
+        F.map(ma.value) {
+          case Ior.Left(e)    => Ior.left(e)
+          case Ior.Right(a)   => Ior.right(a)
+          case Ior.Both(e, _) => Ior.left(e)
+        }
+      }
+
+      override def retcon[A](f: E => E, ma: IorT[F, E, A]): IorT[F, E, A] = IorT[F, E, A] {
+        F.map(ma.value) {
+          case Ior.Left(e)    => Ior.left(f(e))
+          case Ior.Right(a)   => Ior.right(a)
+          case Ior.Both(e, a) => Ior.both(f(e), a)
+        }
+      }
+
+      override def chronicle[A](ior: Ior[E, A]): IorT[F, E, A] = IorT(F.pure(ior))
+    }
+}
+
+object iort extends IorTInstances

--- a/core/src/main/scala/cats/mtl/package.scala
+++ b/core/src/main/scala/cats/mtl/package.scala
@@ -28,5 +28,6 @@ package object mtl {
   private[mtl] type NestedC[F[_], G[_]] = {type l[A] = Nested[F, G, A]}
   private[mtl] type MapC[K] = {type l[V] = Map[K, V]}
   private[mtl] type SortedMapC[K] = {type l[V] = SortedMap[K, V]}
-
+  private[mtl] type IorTC[M[_], A] = {type l[B] = IorT[M, A, B]}
+  private[mtl] type IorC[A] = {type l[B] = Ior[A, B]}
 }

--- a/core/src/main/scala/cats/mtl/syntax/all.scala
+++ b/core/src/main/scala/cats/mtl/syntax/all.scala
@@ -2,8 +2,12 @@ package cats.mtl.syntax
 
 object all
 
-trait AllSyntax extends AskSyntax
-  with ListenSyntax with LocalSyntax
-  with RaiseSyntax with StateSyntax
-  with TellSyntax with EmptySyntax
-
+trait AllSyntax
+    extends AskSyntax
+    with ListenSyntax
+    with LocalSyntax
+    with RaiseSyntax
+    with StateSyntax
+    with TellSyntax
+    with EmptySyntax
+    with ChronicleSyntax

--- a/core/src/main/scala/cats/mtl/syntax/chronicle.scala
+++ b/core/src/main/scala/cats/mtl/syntax/chronicle.scala
@@ -1,0 +1,49 @@
+package cats
+package mtl
+package syntax
+
+import cats.data.Ior
+
+trait ChronicleSyntax {
+  implicit def toChronicleOps[F[_], A](fa: F[A]): ChronicleOps[F, A] = new ChronicleOps[F, A](fa)
+}
+
+final class ChronicleOps[F[_], A](val fa: F[A]) extends AnyVal {
+  def dictate[E](e: E)(implicit chronicle: MonadChronicle[F, E]): F[Unit] = {
+    chronicle.dictate(e)
+  }
+
+  def disclose[E](e: E)(implicit chronicle: MonadChronicle[F, E], monoid: Monoid[A]): F[A] = {
+    chronicle.disclose(e)
+  }
+
+  def confess[E](e: E)(implicit chronicle: MonadChronicle[F, E]): F[A] = {
+    chronicle.confess(e)
+  }
+
+  def materialize[E](implicit chronicle: MonadChronicle[F, E]): F[E Ior A] = {
+    chronicle.materialize(fa)
+  }
+
+  def memento[E](implicit chronicle: MonadChronicle[F, E]): F[Either[E, A]] = {
+    chronicle.memento(fa)
+  }
+
+  def absolve[E](a: => A)(implicit chronicle: MonadChronicle[F, E]): F[A] = {
+    chronicle.absolve(a, fa)
+  }
+
+  def condemn[E](implicit chronicle: MonadChronicle[F, E]): F[A] = {
+    chronicle.condemn(fa)
+  }
+
+  def retcon[E](cc: E => E)(implicit chronicle: MonadChronicle[F, E]): F[A] = {
+    chronicle.retcon(cc, fa)
+  }
+
+  def chronicle[E](ior: E Ior A)(implicit chronicle: MonadChronicle[F, E]): F[A] = {
+    chronicle.chronicle(ior)
+  }
+}
+
+object chronicle extends ChronicleSyntax

--- a/laws/src/main/scala/cats/mtl/laws/MonadChronicleLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/MonadChronicleLaws.scala
@@ -5,7 +5,8 @@ package laws
 import cats.data.Ior
 import cats.laws.{IsEq, IsEqArrow}
 import cats.syntax.functor._
-
+import cats.syntax.apply._
+import cats.syntax.semigroup._
 /**
   * Created by Yuval.Itzchakov on 20/07/2018.
   */
@@ -54,6 +55,14 @@ trait MonadChronicleLaws[F[_], E] {
 
   def pureThenRetconIsPure[A](f: E => E, a: A): IsEq[F[A]] = {
     retcon[A](f, pure(a)) <-> pure(a)
+  }
+
+  def dictateSharkDictateIsDictateSemigroup(e0: E, e: E)(implicit ev: Semigroup[E]): IsEq[F[Unit]] = {
+    dictate(e0) *> dictate(e) <-> dictate(e0 |+| e)
+  }
+
+  def dictateSharkConfessIsConfessSemigroup[A](e0: E, e: E)(implicit ev: Semigroup[E]): IsEq[F[A]] = {
+    dictate(e0) *> confess[A](e) <-> confess[A](e0 |+| e)
   }
 }
 

--- a/laws/src/main/scala/cats/mtl/laws/MonadChronicleLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/MonadChronicleLaws.scala
@@ -1,0 +1,65 @@
+package cats
+package mtl
+package laws
+
+import cats.data.Ior
+import cats.laws.{IsEq, IsEqArrow}
+import cats.syntax.functor._
+
+/**
+  * Created by Yuval.Itzchakov on 20/07/2018.
+  */
+trait MonadChronicleLaws[F[_], E] {
+  implicit val chronicleInstance: MonadChronicle[F, E]
+  implicit val monad: Monad[F] = chronicleInstance.monad
+
+  import chronicleInstance._
+  import monad._
+
+  def dictateThenMaterializeIsBoth(e: E): IsEq[F[E Ior Unit]] = {
+    materialize(dictate(e)) <-> pure(Ior.Both(e, ()))
+  }
+
+  def confessThenMaterializeIsLeft[A](e: E): IsEq[F[E Ior A]] = {
+    materialize[A](confess(e)) <-> pure(Ior.Left(e))
+  }
+
+  def pureThenMaterializeIsRight[A](a: A): IsEq[F[E Ior A]] = {
+    materialize[A](pure(a)) <-> pure(Ior.Right(a))
+  }
+
+  def confessThenAbsolveIsPure[A](a: A, e: E): IsEq[F[A]] = {
+    absolve(a, confess(e)) <-> pure(a)
+  }
+
+  def dictateThenCondemIsConfess[A](e: E): IsEq[F[Unit]] = {
+    condemn(dictate(e)) <-> confess(e)
+  }
+
+  def confessThenMementoIsLeft[A](e: E): IsEq[F[Either[E, A]]] = {
+    memento[A](confess(e)) <-> pure(Left(e))
+  }
+
+  def dictateThenMementoIsDictateRightUnit(e: E): IsEq[F[Either[E, Unit]]] = {
+    memento(dictate(e)) <-> dictate(e).map(_ => Right(()))
+  }
+
+  def confessThenRetconIsConfess[A](f: E => E, e: E): IsEq[F[A]] = {
+    retcon[A](f, confess[A](e)) <-> confess[A](f(e))
+  }
+
+  def dictateThenRetconIsDictate[A](f: E => E, e: E): IsEq[F[Unit]] = {
+    retcon(f, dictate(e)) <-> dictate(f(e))
+  }
+
+  def pureThenRetconIsPure[A](f: E => E, a: A): IsEq[F[A]] = {
+    retcon[A](f, pure(a)) <-> pure(a)
+  }
+}
+
+object MonadChronicleLaws {
+  def apply[F[_], E](implicit instance: MonadChronicle[F, E]): MonadChronicleLaws[F, E] =
+    new MonadChronicleLaws[F, E] {
+      override lazy implicit val chronicleInstance: MonadChronicle[F, E] = instance
+    }
+}

--- a/laws/src/main/scala/cats/mtl/laws/discipline/MonadChronicleTests.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/MonadChronicleTests.scala
@@ -24,7 +24,8 @@ trait MonadChronicleTests[F[_], E] extends Laws {
                                    EqFEIorUnit: Eq[F[E Ior Unit]],
                                    EqFEUnit: Eq[F[Either[E, Unit]]],
                                    EqFIor: Eq[F[E Ior A]],
-                                   EqFEither: Eq[F[Either[E, A]]]): RuleSet = {
+                                   EqFEither: Eq[F[Either[E, A]]],
+                                   SemigroupE: Semigroup[E]): RuleSet = {
     new DefaultRuleSet(
       name = "monadChronicle",
       parent = None,
@@ -37,7 +38,9 @@ trait MonadChronicleTests[F[_], E] extends Laws {
       "dictate then memento is dictate right unit" -> ∀(laws.dictateThenMementoIsDictateRightUnit _),
       "dictate then retcon is dictate" -> ∀(laws.dictateThenRetconIsDictate[A] _),
       "pure then materialize is right" -> ∀(laws.pureThenMaterializeIsRight[A] _),
-      "pure then retcon is pure" -> ∀(laws.pureThenRetconIsPure[A] _)
+      "pure then retcon is pure" -> ∀(laws.pureThenRetconIsPure[A] _),
+      "dictate shark dictate is dictate semigroup" -> ∀(laws.dictateSharkDictateIsDictateSemigroup _),
+      "dictate shark confess is confess semigroup" -> ∀(laws.dictateSharkConfessIsConfessSemigroup[A] _)
     )
   }
 }

--- a/laws/src/main/scala/cats/mtl/laws/discipline/MonadChronicleTests.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/MonadChronicleTests.scala
@@ -1,0 +1,51 @@
+package cats
+package mtl
+package laws
+package discipline
+
+import cats.data.Ior
+import org.scalacheck.Prop.{forAll => ∀}
+import org.scalacheck.{Arbitrary, Cogen}
+import org.typelevel.discipline.Laws
+import cats.kernel.laws.discipline.catsLawsIsEqToProp
+
+trait MonadChronicleTests[F[_], E] extends Laws {
+  implicit val chronicleInstance: MonadChronicle[F, E]
+
+  def laws: MonadChronicleLaws[F, E] = MonadChronicleLaws[F, E]
+
+  def monadChronicle[A: Arbitrary](implicit ArbFA: Arbitrary[F[A]],
+                                   ArbE: Arbitrary[E],
+                                   CogenA: Cogen[A],
+                                   CogenE: Cogen[E],
+                                   EqFU: Eq[F[E]],
+                                   EqFA: Eq[F[A]],
+                                   EqFUnit: Eq[F[Unit]],
+                                   EqFEIorUnit: Eq[F[E Ior Unit]],
+                                   EqFEUnit: Eq[F[Either[E, Unit]]],
+                                   EqFIor: Eq[F[E Ior A]],
+                                   EqFEither: Eq[F[Either[E, A]]]): RuleSet = {
+    new DefaultRuleSet(
+      name = "monadChronicle",
+      parent = None,
+      "confess then absolve is pure" -> ∀(laws.confessThenAbsolveIsPure[A] _),
+      "confess then materialize is left" -> ∀(laws.confessThenMaterializeIsLeft[A] _),
+      "confess then materialize is le" -> ∀(laws.confessThenMementoIsLeft[A] _),
+      "confess then retcon is confess" -> ∀(laws.confessThenRetconIsConfess[A] _),
+      "dictate then condem is confess" -> ∀(laws.dictateThenCondemIsConfess[A] _),
+      "dictate then materialize is both" -> ∀(laws.dictateThenMaterializeIsBoth _),
+      "dictate then memento is dictate right unit" -> ∀(laws.dictateThenMementoIsDictateRightUnit _),
+      "dictate then retcon is dictate" -> ∀(laws.dictateThenRetconIsDictate[A] _),
+      "pure then materialize is right" -> ∀(laws.pureThenMaterializeIsRight[A] _),
+      "pure then retcon is pure" -> ∀(laws.pureThenRetconIsPure[A] _)
+    )
+  }
+}
+
+object MonadChronicleTests {
+  def apply[F[_], E](implicit instance: MonadChronicle[F, E]): MonadChronicleTests[F, E] = {
+    new MonadChronicleTests[F, E] with Laws {
+      override implicit val chronicleInstance: MonadChronicle[F, E] = instance
+    }
+  }
+}

--- a/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
@@ -1,13 +1,14 @@
-package cats.mtl.tests
+package cats
+package mtl
+package tests
 
 import cats.arrow.FunctionK
 import cats.data.Ior
 import cats.instances.all._
+import cats.mtl.instances.chronicle._
 import cats.laws.discipline.SerializableTests
 import cats.laws.discipline.arbitrary._
 import cats.mtl.laws.discipline._
-import cats.mtl.{FunctorLayerFunctor, IorC, IorTC, MonadLayerControl}
-import cats.~>
 import org.scalacheck._
 
 class IorTTests extends BaseSuite {
@@ -24,7 +25,7 @@ class IorTTests extends BaseSuite {
   {
     implicit val monadLayerControl
       : MonadLayerControl.Aux[IorTC[Option, String]#l, Option, IorC[String]#l] =
-      cats.mtl.instances.iort.iorMonadLayerFunctor[Option, String]
+      cats.mtl.instances.iort.iorMonadLayerControl[Option, String]
 
     checkAll("IorT[Option, String, ?]",
              MonadLayerControlTests[IorTC[Option, String]#l, Option, IorC[String]#l]
@@ -36,10 +37,25 @@ class IorTTests extends BaseSuite {
   {
     implicit val functorLayerFunctor: FunctorLayerFunctor[IorTC[Option, String]#l, Option] =
       cats.mtl.instances.iort.iorFunctorLayerFunctor[Option, String]
-    checkAll("IorT[Option, ?]",
+
+    checkAll("IorT[Option, String, ?]",
              FunctorLayerFunctorTests[IorTC[Option, String]#l, Option]
                .functorLayerFunctor[Boolean])
     checkAll("FunctorLayerFunctor[IorT[Option, String, ?], Option]",
              SerializableTests.serializable(functorLayerFunctor))
+  }
+
+  {
+    checkAll(
+      "IorT[Option, String, ?]",
+      MonadChronicleTests[IorTC[Option, String]#l, String]
+        .monadChronicle[String]
+    )
+
+    checkAll(
+      "Ior[Option, String]",
+      MonadChronicleTests[IorC[String]#l, String]
+        .monadChronicle[String]
+    )
   }
 }

--- a/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
@@ -1,0 +1,48 @@
+package cats.mtl.tests
+
+import cats.arrow.FunctionK
+import cats.data.Ior
+import cats.instances.all._
+import cats.laws.discipline.SerializableTests
+import cats.laws.discipline.arbitrary._
+import cats.mtl.laws.discipline._
+import cats.mtl.{FunctorLayerFunctor, IorC, IorTC, MonadLayerControl}
+import cats.~>
+import org.scalacheck._
+
+/**
+  * Created by Yuval.Itzchakov on 16/07/2018.
+  */
+class IorTTests extends BaseSuite {
+  implicit val arbFunctionK: Arbitrary[Option ~> Option] =
+    Arbitrary(Gen.oneOf(new (Option ~> Option) {
+      def apply[A](fa: Option[A]): Option[A] = None
+    }, FunctionK.id[Option]))
+
+  implicit def arbFunctionKIor[A]: Arbitrary[Ior[A, ?] ~> Ior[A, ?]] =
+    Arbitrary(Gen.oneOf(new (Ior[A, ?] ~> Ior[A, ?]) {
+      override def apply[B](fa: Ior[A, B]): Ior[A, B] = fa
+    }, FunctionK.id[Ior[A, ?]]))
+
+  {
+    implicit val monadLayerControl
+      : MonadLayerControl.Aux[IorTC[Option, String]#l, Option, IorC[String]#l] =
+      cats.mtl.instances.iort.iorMonadLayerFunctor[Option, String]
+
+    checkAll("IorT[Option, String, ?]",
+             MonadLayerControlTests[IorTC[Option, String]#l, Option, IorC[String]#l]
+               .monadLayerControl[Boolean, Boolean])
+    checkAll("MonadLayerControl[IorT[Option, String, ?], Option]",
+             SerializableTests.serializable(monadLayerControl))
+  }
+
+  {
+    implicit val functorLayerFunctor: FunctorLayerFunctor[IorTC[Option, String]#l, Option] =
+      cats.mtl.instances.iort.iorFunctorLayerFunctor[Option, String]
+    checkAll("IorT[Option, ?]",
+             FunctorLayerFunctorTests[IorTC[Option, String]#l, Option]
+               .functorLayerFunctor[Boolean])
+    checkAll("FunctorLayerFunctor[IorT[Option, String, ?], Option]",
+             SerializableTests.serializable(functorLayerFunctor))
+  }
+}

--- a/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
@@ -9,6 +9,7 @@ import cats.mtl.instances.chronicle._
 import cats.laws.discipline.SerializableTests
 import cats.laws.discipline.arbitrary._
 import cats.mtl.laws.discipline._
+import cats.mtl.lifting.{FunctorLayerFunctor, MonadLayerControl}
 import org.scalacheck._
 
 class IorTTests extends BaseSuite {

--- a/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
@@ -46,6 +46,8 @@ class IorTTests extends BaseSuite {
   }
 
   {
+    import cats.mtl.instances.writert._
+
     checkAll(
       "IorT[Option, String, ?]",
       MonadChronicleTests[IorTC[Option, String]#l, String]
@@ -53,9 +55,20 @@ class IorTTests extends BaseSuite {
     )
 
     checkAll(
-      "Ior[Option, String]",
+      "Ior[String, String]",
       MonadChronicleTests[IorC[String]#l, String]
         .monadChronicle[String]
     )
+
+    checkAll(
+      "WriterT[Ior[String, ?], Int]",
+      MonadChronicleTests[WriterTC[IorC[String]#l, Int]#l, String].monadChronicle[String]
+    )
+
+    checkAll(
+      "WriterT[IorT[Option, String, ?], Int]",
+      MonadChronicleTests[WriterTC[IorTC[Option, String]#l, Int]#l, String].monadChronicle[String]
+    )
+
   }
 }

--- a/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/IorTTests.scala
@@ -10,9 +10,6 @@ import cats.mtl.{FunctorLayerFunctor, IorC, IorTC, MonadLayerControl}
 import cats.~>
 import org.scalacheck._
 
-/**
-  * Created by Yuval.Itzchakov on 16/07/2018.
-  */
 class IorTTests extends BaseSuite {
   implicit val arbFunctionK: Arbitrary[Option ~> Option] =
     Arbitrary(Gen.oneOf(new (Option ~> Option) {


### PR DESCRIPTION
This is a WIP of https://github.com/typelevel/cats-mtl/issues/32

Adds:

1. MonadChronicle definition
2. MonadChronicle instance for IorT
3. IorT FunctorLayer definition
4. IorT MonadControlLayer definition
5. Basic tests

I would love help with figuring out what the laws for this typeclass should be so I can expand the test suite and add tests for MC. Once we figure that out and see that it holds, I'll add more instance definitions for other MT.