### PR TITLE
Add ApplicativeCensor

### DIFF
--- a/core/src/main/scala/cats/mtl/ApplicativeCensor.scala
+++ b/core/src/main/scala/cats/mtl/ApplicativeCensor.scala
@@ -1,0 +1,21 @@
+package cats
+package mtl
+
+trait ApplicativeCensor[F[_], L] extends FunctorListen[F, L] {
+  val applicative: Applicative[F]
+  val monoid: Monoid[L]
+  override lazy val functor: Functor[F] = applicative
+
+  def censor[A](fa: F[A])(f: L => L): F[A]
+
+  def clear[A](fa: F[A]): F[A]
+}
+
+object ApplicativeCensor {
+  def apply[F[_], L](implicit ev: ApplicativeCensor[F, L]): ApplicativeCensor[F, L] = ev
+}
+
+trait DefaultApplicativeCensor[F[_], L] extends ApplicativeCensor[F, L] with DefaultFunctorListen[F, L] {
+  override def clear[A](fa: F[A]): F[A] =
+    censor(fa)(_ => monoid.empty)
+}

--- a/core/src/main/scala/cats/mtl/instances/all.scala
+++ b/core/src/main/scala/cats/mtl/instances/all.scala
@@ -5,7 +5,7 @@ package instances
 object all extends AllInstances
 
 trait AllInstances extends EitherTInstances
-  with ListenInstances with OptionTInstances
+  with CensorInstances with OptionTInstances
   with RaiseInstances with ReaderTInstances
   with LocalInstances with StateInstances
   with StateTInstances with WriterTInstances

--- a/core/src/main/scala/cats/mtl/instances/ask.scala
+++ b/core/src/main/scala/cats/mtl/instances/ask.scala
@@ -21,8 +21,5 @@ trait AskInstances {
 
 }
 
-private[instances] trait AskInstancesLowPriority1 {
-}
-
 object ask extends AskInstances
 

--- a/core/src/main/scala/cats/mtl/instances/censor.scala
+++ b/core/src/main/scala/cats/mtl/instances/censor.scala
@@ -1,0 +1,143 @@
+package cats
+package mtl
+package instances
+
+import cats.data.{IndexedReaderWriterStateT, ReaderWriterStateT, WriterT}
+import cats.mtl.lifting.MonadLayerControl
+import cats.syntax.functor._
+
+trait CensorInstances extends CensorInstancesLowPriority {
+  implicit final def censorInd[M[_], L, Inner[_], State[_]](implicit
+                                                            layer: MonadLayerControl.Aux[M, Inner, State],
+                                                            under: ApplicativeCensor[Inner, L],
+                                                            monoidL: Monoid[L]
+                                                           ): ApplicativeCensor[M, L] =
+    new ApplicativeCensor[M, L] {
+      val applicative: Applicative[M] = layer.outerInstance
+      val monoid: Monoid[L] = monoidL
+
+      def tell(l: L): M[Unit] = layer.layer(under.tell(l))
+
+      def writer[A](a: A, l: L): M[A] = layer.layer(under.writer(a, l))
+
+      def tuple[A](ta: (L, A)): M[A] = layer.layer(under.tuple(ta))
+
+      def censor[A](fa: M[A])(f: L => L): M[A] =
+        layer.outerInstance.flatMap(layer.layerControl { cps =>
+          under.censor(cps(fa))(f)
+        })(layer.restore)
+
+      def clear[A](fa: M[A]): M[A] =
+        layer.outerInstance.flatMap(layer.layerControl { cps =>
+          under.clear(cps(fa))
+        })(layer.restore)
+
+      def listen[A](fa: M[A]): M[(A, L)] = {
+        layer.outerInstance.flatMap(layer.layerControl { cps =>
+          under.listen(cps(fa))
+        })(x =>
+          layer.outerInstance.map(layer.restore(x._1))(z => (z, x._2))
+        )
+      }
+
+      def listens[A, B](fa: M[A])(f: (L) => B): M[(A, B)] = {
+        layer.outerInstance.map(listen(fa)) { case (a, l) =>
+          (a, f(l))
+        }
+      }
+
+    }
+
+  implicit final def passWriterId[L]
+  (implicit L: Monoid[L]
+  ): ApplicativeCensor[WriterTC[Id, L]#l, L] = {
+    passWriter[Id, L]
+  }
+}
+
+trait CensorInstancesLowPriority {
+  implicit final def passWriter[M[_], L]
+  (implicit M: Monad[M], L: Monoid[L]
+  ): ApplicativeCensor[WriterT[M, L, ?], L] =
+    new ApplicativeCensor[WriterT[M, L, ?], L] {
+      val applicative: Applicative[WriterT[M, L, ?]] =
+        cats.data.WriterT.catsDataMonadForWriterT[M, L]
+
+      val monoid: Monoid[L] = L
+
+      def clear[A](fa: WriterT[M, L, A]): WriterT[M, L, A] =
+        WriterT(fa.value.tupleLeft(L.empty))
+
+      def censor[A](fa: WriterT[M, L, A])(f: L => L): WriterT[M, L, A] =
+        WriterT(fa.run.map { case (l, a) => (f(l), a) })
+
+      def tell(l: L): WriterT[M, L, Unit] = WriterT.tell(l)
+
+      def writer[A](a: A, l: L): WriterT[M, L, A] = WriterT.put(a)(l)
+
+      def tuple[A](ta: (L, A)): WriterT[M, L, A] = WriterT(M.pure(ta))
+
+      def listen[A](fa: WriterT[M, L, A]): WriterT[M, L, (A, L)] =
+        WriterT[M, L, (A, L)](fa.run.map { case (l, a) => (l, (a, l)) })
+
+      def listens[A, B](fa: WriterT[M, L, A])(f: (L) => B): WriterT[M, L, (A, B)] =
+        WriterT[M, L, (A, B)](fa.run.map { case (l, a) => (l, (a, f(l))) })
+    }
+
+  implicit final def passTuple[L]
+  (implicit L: Monoid[L]
+  ): ApplicativeCensor[(L, ?), L] =
+    new ApplicativeCensor[(L, ?), L] {
+      val applicative: Applicative[Tuple2[L, ?]] =
+        cats.instances.tuple.catsStdMonadForTuple2
+
+      val monoid: Monoid[L] = L
+
+      def tell(l: L): (L, Unit) = (l, ())
+
+      def writer[A](a: A, l: L): (L, A) = (l, a)
+
+      def tuple[A](ta: (L, A)): (L, A) = ta
+
+      def clear[A](fa: (L, A)): (L, A) = (L.empty, fa._2)
+
+      def censor[A](fa: (L, A))(f: L => L): (L, A) = {
+        val (l, a) = fa
+        (f(l), a)
+      }
+
+      def listen[A](fa: (L, A)): (L, (A, L)) = {
+        val (l, a) = fa
+        (l, (a, l))
+      }
+
+      def listens[A, B](fa: (L, A))(f: (L) => B): (L, (A, B)) = {
+        val (l, a) = fa
+        (l, (a, f(l)))
+      }
+    }
+
+  implicit final def passReaderWriterState[M[_], R, L, S]
+  (implicit L: Monoid[L], M: Monad[M]): ApplicativeCensor[ReaderWriterStateT[M, R, L, S, ?], L] =
+    new DefaultApplicativeCensor[ReaderWriterStateT[M, R, L, S, ?], L] {
+      val applicative: Applicative[ReaderWriterStateT[M, R, L, S, ?]] =
+        IndexedReaderWriterStateT.catsDataMonadForRWST
+
+      val monoid: Monoid[L] = L
+
+      def tell(l: L): ReaderWriterStateT[M, R, L, S, Unit] = ReaderWriterStateT.tell(l)
+
+      def listen[A](fa: ReaderWriterStateT[M, R, L, S, A]): ReaderWriterStateT[M, R, L, S, (A, L)] =
+        ReaderWriterStateT((e, s) => fa.run(e, s).map {
+          case (l, s, a) => (l, s, (a, l))
+        })
+
+      def censor[A](faf: ReaderWriterStateT[M, R, L, S, A])(f: L => L): ReaderWriterStateT[M, R, L, S, A] =
+        ReaderWriterStateT((e, s) => faf.run(e, s).map {
+          case (l, s, a) => (f(l), s, a)
+        })
+
+    }
+}
+
+object censor extends CensorInstances

--- a/core/src/main/scala/cats/mtl/instances/listen.scala
+++ b/core/src/main/scala/cats/mtl/instances/listen.scala
@@ -2,11 +2,9 @@ package cats
 package mtl
 package instances
 
-import cats.data.{IndexedReaderWriterStateT, ReaderWriterStateT, WriterT}
 import cats.mtl.lifting.MonadLayerControl
-import cats.syntax.functor._
 
-trait ListenInstances extends ListenInstancesLowPriority {
+trait ListenInstances {
 
   implicit final def listenInd[M[_], L, Inner[_], State[_]](implicit
                                                             layer: MonadLayerControl.Aux[M, Inner, State],
@@ -38,77 +36,6 @@ trait ListenInstances extends ListenInstancesLowPriority {
 
     }
   }
-
-  implicit final def listenWriterId[L]
-  (implicit L: Monoid[L]
-  ): FunctorListen[WriterTC[Id, L]#l, L] = {
-    listenWriter[Id, L]
-  }
-}
-
-trait ListenInstancesLowPriority {
-  implicit final def listenWriter[M[_], L]
-  (implicit M: Monad[M], L: Monoid[L]
-  ): FunctorListen[WriterTC[M, L]#l, L] = {
-    new FunctorListen[WriterTC[M, L]#l, L] {
-      val functor = new Functor[WriterTC[M, L]#l] {
-        def map[A, B](fa: WriterT[M, L, A])(f: (A) => B): WriterT[M, L, B] = fa.map(f)
-      }
-
-      def tell(l: L): WriterT[M, L, Unit] = WriterT.tell(l)
-
-      def writer[A](a: A, l: L): WriterT[M, L, A] = WriterT.put(a)(l)
-
-      def tuple[A](ta: (L, A)): WriterT[M, L, A] = WriterT(M.pure(ta))
-
-      def listen[A](fa: WriterT[M, L, A]): WriterT[M, L, (A, L)] = {
-        WriterT[M, L, (A, L)](fa.run.map { case (l, a) => (l, (a, l)) })
-      }
-
-      def listens[A, B](fa: WriterT[M, L, A])(f: (L) => B): WriterT[M, L, (A, B)] = {
-        WriterT[M, L, (A, B)](fa.run.map { case (l, a) => (l, (a, f(l))) })
-      }
-
-    }
-  }
-
-  implicit final def listenTuple[L]
-  (implicit L: Monoid[L]
-  ): FunctorListen[TupleC[L]#l, L] = {
-    new FunctorListen[TupleC[L]#l, L] {
-      val functor = cats.instances.tuple.catsStdMonadForTuple2
-
-      def tell(l: L): (L, Unit) = (l, ())
-
-      def writer[A](a: A, l: L): (L, A) = (l, a)
-
-      def tuple[A](ta: (L, A)): (L, A) = ta
-
-      def listen[A](fa: (L, A)): (L, (A, L)) = {
-        val (l, a) = fa
-        (l, (a, l))
-      }
-
-      def listens[A, B](fa: (L, A))(f: (L) => B): (L, (A, B)) = {
-        val (l, a) = fa
-        (l, (a, f(l)))
-      }
-    }
-  }
-
-  implicit final def listenReaderWriterState[M[_], R, L, S]
-  (implicit L: Monoid[L], M: Monad[M]): FunctorListen[ReaderWriterStateT[M, R, L, S, ?], L] =
-    new DefaultFunctorListen[ReaderWriterStateT[M, R, L, S, ?], L] {
-      val functor: Functor[ReaderWriterStateT[M, R, L, S, ?]] =
-        IndexedReaderWriterStateT.catsDataMonadForRWST
-
-      def tell(l: L): ReaderWriterStateT[M, R, L, S, Unit] = ReaderWriterStateT.tell(l)
-
-      def listen[A](fa: ReaderWriterStateT[M, R, L, S, A]): ReaderWriterStateT[M, R, L, S, (A, L)] =
-        ReaderWriterStateT((e, s) => fa.run(e, s).map {
-          case (l, s, a) => (l, s, (a, l))
-        })
-    }
 }
 
 object listen extends ListenInstances

--- a/laws/src/main/scala/cats/mtl/laws/ApplicativeCensorLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/ApplicativeCensorLaws.scala
@@ -1,0 +1,38 @@
+package cats
+package mtl
+package laws
+
+import cats.laws.IsEq
+import cats.laws.IsEqArrow
+import cats.syntax.all._
+
+trait ApplicativeCensorLaws[F[_], L] extends FunctorListenLaws[F, L] {
+  implicit def F: ApplicativeCensor[F, L]
+
+  implicit def L: Monoid[L] = F.monoid
+  implicit def A: Applicative[F] = F.applicative
+
+  def tellRightProductHomomorphism(l1: L, l2: L): IsEq[F[Unit]] =
+    (F.tell(l1) *> F.tell(l2)) <-> F.tell(l1 |+| l2)
+
+  def tellLeftProductHomomorphism(l1: L, l2: L): IsEq[F[Unit]] =
+    (F.tell(l1) <* F.tell(l2)) <-> F.tell(l1 |+| l2)
+
+  def censorWithPurIsTellEmpty[A](a: A, f: L => L): IsEq[F[A]] =
+    F.censor(A.pure(a))(f) <-> F.tell(f(L.empty)).as(a)
+
+  def clearIsIdempotent[A](fa: F[A]): IsEq[F[A]] =
+    F.clear(F.clear(fa)) <-> F.clear(fa)
+
+  def tellAndClearIsPureUnit(l: L): IsEq[F[Unit]] =
+    F.clear(F.tell(l)) <-> A.pure(())
+
+}
+
+object ApplicativeCensorLaws {
+  def apply[F[_], L](implicit instance0: ApplicativeCensor[F, L]): ApplicativeCensorLaws[F, L] = {
+    new ApplicativeCensorLaws[F, L] {
+      def F: ApplicativeCensor[F, L] = instance0
+    }
+  }
+}

--- a/laws/src/main/scala/cats/mtl/laws/FunctorListenLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/FunctorListenLaws.scala
@@ -7,29 +7,27 @@ import cats.laws.IsEqArrow
 import cats.syntax.functor._
 
 trait FunctorListenLaws[F[_], L] extends FunctorTellLaws[F, L] {
-  implicit val listenInstance: FunctorListen[F, L]
-  import listenInstance.{tell, listen, listens}
+  implicit def F: FunctorListen[F, L]
 
   // external laws:
   def listenRespectsTell(l: L): IsEq[F[(Unit, L)]] = {
-    listen(tell(l)) <-> tell(l).as(((), l))
+    F.listen(F.tell(l)) <-> F.tell(l).as(((), l))
   }
 
   def listenAddsNoEffects[A](fa: F[A]): IsEq[F[A]] = {
-    listen(fa).map(_._1) <-> fa
+    F.listen(fa).map(_._1) <-> fa
   }
 
   // internal law:
   def listensIsListenThenMap[A, B](fa: F[A], f: L => B): IsEq[F[(A, B)]] = {
-    listens(fa)(f) <-> listen(fa).map { case (a, l) => (a, f(l)) }
+    F.listens(fa)(f) <-> F.listen(fa).map { case (a, l) => (a, f(l)) }
   }
 }
 
 object FunctorListenLaws {
   def apply[F[_], E](implicit instance0: FunctorListen[F, E]): FunctorListenLaws[F, E] = {
     new FunctorListenLaws[F, E] {
-      override lazy val listenInstance: FunctorListen[F, E] = instance0
-      override lazy val tellInstance: FunctorTell[F, E] = instance0
+      def F: FunctorListen[F, E] = instance0
     }
   }
 }

--- a/laws/src/main/scala/cats/mtl/laws/FunctorTellLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/FunctorTellLaws.scala
@@ -7,18 +7,16 @@ import cats.laws.IsEqArrow
 import cats.syntax.functor._
 
 trait FunctorTellLaws[F[_], L] {
-  implicit val tellInstance: FunctorTell[F, L]
-  implicit val functor: Functor[F] = tellInstance.functor
-
-  import tellInstance._
+  implicit def F: FunctorTell[F, L]
+  implicit def functor(implicit F: FunctorTell[F, L]): Functor[F] = F.functor
 
   // internal laws:
   def writerIsTellAndMap[A](a: A, l: L): IsEq[F[A]] = {
-    (tell(l) as a) <-> writer(a, l)
+    F.tell(l).as(a) <-> F.writer(a, l)
   }
 
   def tupleIsWriterFlipped[A](a: A, l: L): IsEq[F[A]] = {
-    writer(a, l) <-> tuple((l, a))
+    F.writer(a, l) <-> F.tuple((l, a))
   }
 
 }
@@ -26,7 +24,7 @@ trait FunctorTellLaws[F[_], L] {
 object FunctorTellLaws {
   def apply[F[_], L](implicit instance0: FunctorTell[F, L]): FunctorTellLaws[F, L] = {
     new FunctorTellLaws[F, L] {
-      override lazy val tellInstance: FunctorTell[F, L] = instance0
+      def F: FunctorTell[F, L] = instance0
     }
   }
 }

--- a/laws/src/main/scala/cats/mtl/laws/discipline/ApplicativeCensorTests.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/ApplicativeCensorTests.scala
@@ -1,0 +1,42 @@
+package cats
+package mtl
+package laws
+package discipline
+
+import org.scalacheck.Prop.{forAll => ∀}
+import org.scalacheck.{Arbitrary, Cogen}
+import cats.kernel.laws.discipline.catsLawsIsEqToProp
+
+trait ApplicativeCensorTests[F[_], L] extends FunctorListenTests[F, L] {
+  def laws: ApplicativeCensorLaws[F, L]
+
+  def applicativeCensor[A: Arbitrary, B: Arbitrary](implicit
+                                                    ArbFA: Arbitrary[F[A]],
+                                                    ArbL: Arbitrary[L],
+                                                    CogenA: Cogen[A],
+                                                    CogenL: Cogen[L],
+                                                    EqFU: Eq[F[Unit]],
+                                                    EqFA: Eq[F[A]],
+                                                    EqFAB: Eq[F[(A, B)]],
+                                                    EqFUL: Eq[F[(Unit, L)]]
+                                                 ): RuleSet = {
+    new DefaultRuleSet(
+      name = "applicativeCensor",
+      parent = Some(functorListen[A, B]),
+      "tell leftProduct is tell combined" -> ∀(laws.tellLeftProductHomomorphism _),
+      "tell rightProduct is tell combined" -> ∀(laws.tellRightProductHomomorphism _),
+      "censor with pure is tell with empty" -> ∀(laws.censorWithPurIsTellEmpty[A] _),
+      "tell and clear is pure unit" -> ∀(laws.tellAndClearIsPureUnit _),
+      "clear is idempotent" -> ∀(laws.clearIsIdempotent[A] _)
+    )
+  }
+
+}
+
+object ApplicativeCensorTests {
+  def apply[F[_], L](implicit instance0: ApplicativeCensor[F, L]): ApplicativeCensorTests[F, L] = {
+    new ApplicativeCensorTests[F, L] {
+      override def laws: ApplicativeCensorLaws[F, L] = ApplicativeCensorLaws[F, L]
+    }
+  }
+}

--- a/laws/src/main/scala/cats/mtl/laws/discipline/FunctorListenTests.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/FunctorListenTests.scala
@@ -5,12 +5,10 @@ package discipline
 
 import org.scalacheck.Prop.{forAll => ∀}
 import org.scalacheck.{Arbitrary, Cogen}
-import org.typelevel.discipline.Laws
 import cats.kernel.laws.discipline.catsLawsIsEqToProp
 
 trait FunctorListenTests[F[_], L] extends FunctorTellTests[F, L] {
-  implicit val listenInstance: FunctorListen[F, L]
-  override def laws: FunctorListenLaws[F, L] = FunctorListenLaws[F, L]
+  def laws: FunctorListenLaws[F, L]
 
   def functorListen[A: Arbitrary, B: Arbitrary](implicit
                                                     ArbFA: Arbitrary[F[A]],
@@ -35,9 +33,8 @@ trait FunctorListenTests[F[_], L] extends FunctorTellTests[F, L] {
 
 object FunctorListenTests {
   def apply[F[_], L](implicit instance0: FunctorListen[F, L]): FunctorListenTests[F, L] = {
-    new FunctorListenTests[F, L] with Laws {
-      override val listenInstance: FunctorListen[F, L] = instance0
-      override implicit val tellInstance: FunctorTell[F, L] = instance0
+    new FunctorListenTests[F, L] {
+      override def laws: FunctorListenLaws[F, L] = FunctorListenLaws[F, L]
     }
   }
 }

--- a/laws/src/main/scala/cats/mtl/laws/discipline/FunctorTellTests.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/FunctorTellTests.scala
@@ -9,8 +9,7 @@ import org.typelevel.discipline.Laws
 import cats.kernel.laws.discipline.catsLawsIsEqToProp
 
 trait FunctorTellTests[F[_], L] extends Laws {
-  implicit val tellInstance: FunctorTell[F, L]
-  def laws: FunctorTellLaws[F, L] = FunctorTellLaws[F, L]
+  def laws: FunctorTellLaws[F, L]
 
   def functorTell[A: Arbitrary](implicit
                                     ArbFA: Arbitrary[F[A]],
@@ -31,8 +30,8 @@ trait FunctorTellTests[F[_], L] extends Laws {
 
 object FunctorTellTests {
   def apply[F[_], L](implicit instance0: FunctorTell[F, L]): FunctorTellTests[F, L] = {
-    new FunctorTellTests[F, L] with Laws {
-      override implicit val tellInstance: FunctorTell[F, L] = instance0
+    new FunctorTellTests[F, L] {
+      override def laws: FunctorTellLaws[F, L] = FunctorTellLaws[F, L]
     }
   }
 }

--- a/tests/src/test/scala/cats/mtl/tests/ReaderWriterStateTTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/ReaderWriterStateTTests.scala
@@ -9,7 +9,7 @@ import cats.laws.discipline._
 import cats.laws.discipline.eq._
 import cats.mtl._
 import cats.mtl.implicits._
-import cats.mtl.laws.discipline.{ApplicativeAskTests, FunctorTellTests, MonadLayerControlTests, MonadStateTests}
+import cats.mtl.laws.discipline._
 import cats.mtl.lifting.MonadLayerControl
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -46,15 +46,15 @@ class ReaderWriterStateTTests extends StateTTestsBase {
     SerializableTests.serializable(MonadState[ReaderWriterStateT[Option, Boolean, Int, String, ?], String]))
 
   checkAll("ReaderWriterStateT[Option, Boolean, Int, String, Int]",
-    FunctorTellTests[ReaderWriterStateT[Option, Boolean, Int, String, ?], Int]
-      .functorTell[Int])
-  checkAll("FunctorTell[ReaderWriterStateT[Option, Boolean, Int, String, ?]]",
-    SerializableTests.serializable(FunctorTell[ReaderWriterStateT[Option, Boolean, Int, String, ?], Int]))
+    ApplicativeCensorTests[ReaderWriterStateT[Option, Boolean, Int, String, ?], Int]
+      .applicativeCensor[Int, String])
+  checkAll("ApplicativeCensor[ReaderWriterStateT[Option, Boolean, Int, String, ?]]",
+    SerializableTests.serializable(ApplicativeCensor[ReaderWriterStateT[Option, Boolean, Int, String, ?], Int]))
 
   checkAll("ReaderWriterStateT[Option, Boolean, Int, String, Boolean]",
-    ApplicativeAskTests[ReaderWriterStateT[Option, Boolean, Int, String, ?], Boolean]
-      .applicativeAsk[Boolean])
-  checkAll("ApplicativeAsk[ReaderWriterStateT[Option, Boolean, Int, String, ?]]",
-    SerializableTests.serializable(ApplicativeAsk[ReaderWriterStateT[Option, Boolean, Int, String, ?], Boolean]))
+    ApplicativeLocalTests[ReaderWriterStateT[Option, Boolean, Int, String, ?], Boolean]
+      .applicativeLocal[Boolean, String])
+  checkAll("ApplicativeLocal[ReaderWriterStateT[Option, Boolean, Int, String, ?]]",
+    SerializableTests.serializable(ApplicativeLocal[ReaderWriterStateT[Option, Boolean, Int, String, ?], Boolean]))
 
 }

--- a/tests/src/test/scala/cats/mtl/tests/TupleTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/TupleTests.scala
@@ -8,13 +8,13 @@ import cats.instances.all._
 import cats.laws.discipline.SerializableTests
 import cats.mtl.instances.all._
 import cats.laws.discipline.arbitrary._
-import cats.mtl.laws.discipline.FunctorListenTests
+import cats.mtl.laws.discipline.ApplicativeCensorTests
 
 class TupleTests extends BaseSuite {
-  checkAll("FunctorListen[(String, ?), String]",
-    FunctorListenTests[TupleC[String]#l, String]
-      .functorListen[String, String])
-  checkAll("FunctorListen[(String, ?), String]",
-    SerializableTests.serializable(FunctorListen[TupleC[String]#l, String]))
+  checkAll("ApplicativeCensor[(String, ?), String]",
+    ApplicativeCensorTests[TupleC[String]#l, String]
+      .applicativeCensor[String, String])
+  checkAll("ApplicativeCensor[(String, ?), String]",
+    SerializableTests.serializable(ApplicativeCensor[TupleC[String]#l, String]))
 }
 

--- a/tests/src/test/scala/cats/mtl/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/WriterTTests.scala
@@ -7,8 +7,8 @@ import cats.arrow.FunctionK
 import cats.data._
 import cats.instances.all._
 import cats.laws.discipline.SerializableTests
-import cats.mtl.instances.listen._
 import cats.laws.discipline.eq._
+import cats.laws.discipline.arbitrary._
 import cats.mtl.laws.discipline._
 import cats.mtl.lifting.{ApplicativeLayerFunctor, FunctorLayerFunctor, MonadLayerControl}
 import org.scalacheck._
@@ -31,60 +31,36 @@ class WriterTTests extends BaseSuite {
   type WriterTStringOverWriterTStringOverOption[A] = WriterT[WriterTC[Option, String]#l, List[Int], A]
 
   locally {
-    // I know, this is unbelievably odd.
-    // The reason this is in its own scope is that the Arbitrary and Eq instance induction for WriterT
-    // is detected as "divergent" by 2.10, so I have to isolate the *rest* of the imports in the file,
-    locally {
-      import cats.mtl.instances.listen._, cats.mtl.instances.writert._
-      //      implicit val listen = FunctorListen[WriterTStringOverWriterTStringOverOption, String]
-      implicit val arb = cats.laws.discipline.arbitrary.catsLawsArbitraryForWriterT[WriterTC[Option, String]#l, List[Int], String](
-        cats.laws.discipline.arbitrary.catsLawsArbitraryForWriterT[Option, String, (List[Int], String)]
-      )
-      implicit val eqS = WriterT.catsDataEqForWriterT[WriterTC[Option, String]#l, List[Int], String](
-        WriterT.catsDataEqForWriterT[Option, String, (List[Int], String)]
-      )
-      implicit val eqSS = WriterT.catsDataEqForWriterT[WriterTC[Option, String]#l, List[Int], (String, String)](
-        WriterT.catsDataEqForWriterT[Option, String, (List[Int], (String, String))]
-      )
-      implicit val eqUS = WriterT.catsDataEqForWriterT[WriterTC[Option, String]#l, List[Int], (Unit, String)](
-        WriterT.catsDataEqForWriterT[Option, String, (List[Int], (Unit, String))]
-      )
-      implicit val eqU = WriterT.catsDataEqForWriterT[WriterTC[Option, String]#l, List[Int], Unit](
-        WriterT.catsDataEqForWriterT[Option, String, (List[Int], Unit)]
-      )
-      // this diverges in 2.10. Maybe just don't promise it?
-      checkAll("WriterT[WriterTC[Option, String]#l, List[Int], String]",
-        FunctorListenTests[WriterTStringOverWriterTStringOverOption, String]
-          .functorListen[String, String]
-      )
-      checkAll("FunctorListen[WriterT[WriterTC[Option, String]#l, List[Int], String]",
-        SerializableTests.serializable(FunctorListen[WriterTStringOverWriterTStringOverOption, String]))
-    }
-
-    locally {
       import cats.laws.discipline.arbitrary._
       import cats.mtl.instances.all._
 
+      checkAll("WriterT[WriterTC[Option, String]#l, List[Int], String]",
+        ApplicativeCensorTests[WriterTStringOverWriterTStringOverOption, String]
+          .applicativeCensor[String, String]
+      )
+      checkAll("ApplicativePass[WriterT[WriterTC[Option, String]#l, List[Int], String]",
+        SerializableTests.serializable(ApplicativeCensor[WriterTStringOverWriterTStringOverOption, String]))
+
       checkAll("ReaderT[WriterTC[Option, String]#l, List[Int], String]",
-        FunctorListenTests[ReaderTStringOverWriterTStringOverOption, String]
-          .functorListen[String, String])
-      checkAll("FunctorListen[ReaderT[WriterTC[Option, String]#l, List[Int], String]",
-        SerializableTests.serializable(FunctorListen[ReaderTStringOverWriterTStringOverOption, String]))
+        ApplicativeCensorTests[ReaderTStringOverWriterTStringOverOption, String]
+          .applicativeCensor[String, String])
+      checkAll("ApplicativePass[ReaderT[WriterTC[Option, String]#l, List[Int], String]",
+        SerializableTests.serializable(ApplicativeCensor[ReaderTStringOverWriterTStringOverOption, String]))
 
       checkAll("StateT[WriterTC[Option, String]#l, List[Int], String]",
-        FunctorListenTests[StateTStringOverWriterTStringOverOption, String]
-          .functorListen[String, String])
-      checkAll("FunctorListen[StateT[WriterTC[Option, String]#l, List[Int], String]",
-        SerializableTests.serializable(FunctorListen[StateTStringOverWriterTStringOverOption, String]))
-    }
+        ApplicativeCensorTests[StateTStringOverWriterTStringOverOption, String]
+          .applicativeCensor[String, String])
+      checkAll("ApplicativePass[StateT[WriterTC[Option, String]#l, List[Int], String]",
+        SerializableTests.serializable(ApplicativeCensor[StateTStringOverWriterTStringOverOption, String]))
   }
 
   locally {
     import cats.laws.discipline.arbitrary._
+    import cats.mtl.instances.censor._
 
     checkAll("WriterT[Option, String, String]",
-      FunctorListenTests[WriterTC[Option, String]#l, String]
-        .functorListen[String, String])
+      ApplicativeCensorTests[WriterTC[Option, String]#l, String]
+        .applicativeCensor[String, String])
     checkAll("FunctorListen[WriterT[Option, String, ?]]",
       SerializableTests.serializable(FunctorListen[WriterTC[Option, String]#l, String]))
 


### PR DESCRIPTION
This plays into #71, it's not quite the `ApplicativePass` I proposed there, but a slightly weaker `ApplicativeCensor` that cannot use the `F` context to build the function. This was done, so that it can be lifted through transformer stacks, which wasn't possible otherwise.