### PR TITLE
Fix MonadChronicle signatures and ops syntax

### DIFF
--- a/core/src/main/scala/cats/mtl/syntax/chronicle.scala
+++ b/core/src/main/scala/cats/mtl/syntax/chronicle.scala
@@ -6,21 +6,11 @@ import cats.data.Ior
 
 trait ChronicleSyntax {
   implicit def toChronicleOps[F[_], A](fa: F[A]): ChronicleOps[F, A] = new ChronicleOps[F, A](fa)
+  implicit def toChronicleIdOps[E](e: E): ChronicleIdOps[E] = new ChronicleIdOps[E](e)
+  implicit def toChronicleIorOps[A, E](ior: E Ior A): ChronicleIorOps[A, E] = new ChronicleIorOps[A, E](ior)
 }
 
 final class ChronicleOps[F[_], A](val fa: F[A]) extends AnyVal {
-  def dictate[E](e: E)(implicit chronicle: MonadChronicle[F, E]): F[Unit] = {
-    chronicle.dictate(e)
-  }
-
-  def disclose[E](e: E)(implicit chronicle: MonadChronicle[F, E], monoid: Monoid[A]): F[A] = {
-    chronicle.disclose(e)
-  }
-
-  def confess[E](e: E)(implicit chronicle: MonadChronicle[F, E]): F[A] = {
-    chronicle.confess(e)
-  }
-
   def materialize[E](implicit chronicle: MonadChronicle[F, E]): F[E Ior A] = {
     chronicle.materialize(fa)
   }
@@ -30,7 +20,7 @@ final class ChronicleOps[F[_], A](val fa: F[A]) extends AnyVal {
   }
 
   def absolve[E](a: => A)(implicit chronicle: MonadChronicle[F, E]): F[A] = {
-    chronicle.absolve(a, fa)
+    chronicle.absolve(fa)(a)
   }
 
   def condemn[E](implicit chronicle: MonadChronicle[F, E]): F[A] = {
@@ -38,10 +28,26 @@ final class ChronicleOps[F[_], A](val fa: F[A]) extends AnyVal {
   }
 
   def retcon[E](cc: E => E)(implicit chronicle: MonadChronicle[F, E]): F[A] = {
-    chronicle.retcon(cc, fa)
+    chronicle.retcon(fa)(cc)
   }
+}
 
-  def chronicle[E](ior: E Ior A)(implicit chronicle: MonadChronicle[F, E]): F[A] = {
+final class ChronicleIdOps[E](val e: E) extends AnyVal {
+  def dictate[F[_]](implicit chronicle: MonadChronicle[F, E]): F[Unit] = {
+      chronicle.dictate(e)
+    }
+
+  def disclose[F[_], A](implicit chronicle: MonadChronicle[F, E], monoid: Monoid[A]): F[A] = {
+      chronicle.disclose(e)
+    }
+
+  def confess[F[_], A](implicit chronicle: MonadChronicle[F, E]): F[A] = {
+      chronicle.confess(e)
+    }
+}
+
+final class ChronicleIorOps[A, E](val ior: E Ior A) extends AnyVal {
+  def chronicle[F[_]](implicit chronicle: MonadChronicle[F, E]): F[A] = {
     chronicle.chronicle(ior)
   }
 }

--- a/laws/src/main/scala/cats/mtl/laws/MonadChronicleLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/MonadChronicleLaws.scala
@@ -30,7 +30,7 @@ trait MonadChronicleLaws[F[_], E] {
   }
 
   def confessThenAbsolveIsPure[A](a: A, e: E): IsEq[F[A]] = {
-    absolve(a, confess(e)) <-> pure(a)
+    absolve(confess[A](e))(a) <-> pure(a)
   }
 
   def dictateThenCondemIsConfess[A](e: E): IsEq[F[Unit]] = {
@@ -46,15 +46,15 @@ trait MonadChronicleLaws[F[_], E] {
   }
 
   def confessThenRetconIsConfess[A](f: E => E, e: E): IsEq[F[A]] = {
-    retcon[A](f, confess[A](e)) <-> confess[A](f(e))
+    retcon(confess[A](e))(f) <-> confess[A](f(e))
   }
 
   def dictateThenRetconIsDictate[A](f: E => E, e: E): IsEq[F[Unit]] = {
-    retcon(f, dictate(e)) <-> dictate(f(e))
+    retcon(dictate(e))(f) <-> dictate(f(e))
   }
 
   def pureThenRetconIsPure[A](f: E => E, a: A): IsEq[F[A]] = {
-    retcon[A](f, pure(a)) <-> pure(a)
+    retcon(pure(a))(f) <-> pure(a)
   }
 
   def dictateSharkDictateIsDictateSemigroup(e0: E, e: E)(implicit ev: Semigroup[E]): IsEq[F[Unit]] = {

--- a/tests/src/test/scala/cats/mtl/tests/Syntax.scala
+++ b/tests/src/test/scala/cats/mtl/tests/Syntax.scala
@@ -78,14 +78,14 @@ final class Syntax extends BaseSuite {
           IorT.pure[Option, String](42))
 
       val fa: IorT[Option, String, Int] = IorT.pure(42)
-      val dictate: IorT[Option, String, Unit] = fa.dictate("err")
-      val disclose: IorT[Option, String, Int] = fa.disclose("err")
-      val confess: IorT[Option, String, Int] = fa.confess("err")
-      val memento: IorT[Option, String, Either[String, Int]] = fa.memento[String]
+      val dictate: IorT[Option, String, Unit] = "err".dictate[IorTC[Option, String]#l]
+      val disclose: IorT[Option, String, Int] = "err".disclose[IorTC[Option, String]#l, Int]
+      val confess: IorT[Option, String, Int] = "err".confess[IorTC[Option, String]#l, Int]
+      val memento: IorT[Option, String, Either[String, Int]] = fa.memento
       val absolve: IorT[Option, String, Int] = fa.absolve(42)
       val condemn: IorT[Option, String, Int] = fa.condemn
       val retcon: IorT[Option, String, Int] = fa.retcon((str: String) => str + "err")
-      val chronicle: IorT[Option, String, Int] = fa.chronicle[String](Ior.both("hello", 42))
+      val chronicle: IorT[Option, String, Int] = Ior.both("hello", 42).chronicle[IorTC[Option, String]#l]
     }
   }
 }


### PR DESCRIPTION
I've found some issues in the `MonadChronicle` typeclass:

- [x] Signatures of a few functions were copied from Haskell as is, while in `cats` another order of arguments is preferred. (fixed)
- [x] Some ops functions wrongly extend `F[A]` value, which is not used. There should be several ops extensions for different types. (fixed)
- [x] (**declined**) `disclose` requires `Monoid[A]` instance, which is too strong. Actually it is enough to have `Empty[A]` (as in Haskell implementation). But I haven't changed it and would like to discuss it at first