### PR TITLE
Add ApplicativeAsk.const

### DIFF
--- a/core/src/main/scala/cats/mtl/ApplicativeAsk.scala
+++ b/core/src/main/scala/cats/mtl/ApplicativeAsk.scala
@@ -33,6 +33,11 @@ object ApplicativeAsk {
 
   def apply[F[_], E](implicit applicativeAsk: ApplicativeAsk[F, E]): ApplicativeAsk[F, E] = applicativeAsk
 
+  def const[F[_]: Applicative, E](e: E): ApplicativeAsk[F, E] = new DefaultApplicativeAsk[F, E] {
+    val applicative: Applicative[F] = Applicative[F]
+    val ask: F[E] = applicative.pure(e)
+  }
+
   def ask[F[_], E](implicit ask: ApplicativeAsk[F, E]): F[E] = {
     ask.ask
   }

--- a/tests/src/test/scala/cats/mtl/tests/DefaultImplementationTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/DefaultImplementationTests.scala
@@ -67,8 +67,14 @@ class ApplicativeAskDefaultTests extends BaseSuite {
     def ask: FunctionC[Int]#l[Int] = identity
   }
 
-  checkAll("FunctionC[Int]#l[Int]",
+  val pureApplicativeAsk: ApplicativeAsk[FunctionC[Int]#l, Int] = ApplicativeAsk.const(42)
+
+  checkAll("DefaultApplicativeAsk FunctionC[Int]#l[Int]",
     ApplicativeAskTests[FunctionC[Int]#l, Int](defaultApplicativeAsk)
+      .applicativeAsk[String])
+
+  checkAll("ApplicativeAsk.const FunctionC[Int]#l[Int]",
+    ApplicativeAskTests[FunctionC[Int]#l, Int](pureApplicativeAsk)
       .applicativeAsk[String])
 }
 


### PR DESCRIPTION
This PR adds a handy way to create an ApplicativeAsk instance that always answers with the same value.
Useful for when you optimize your program by dropping Reader from your transformer stack and rely on a custom Applicative instance that just wraps over a constant value known at the point of creating it.