### PR TITLE
Add atomic modify+get to MonadState

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -4,8 +4,4 @@
 -Xmx6G
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
--XX:-UseGCOverheadLimit
-# effectively adds GC to Perm space
--XX:+CMSClassUnloadingEnabled
-# must be enabled for CMSClassUnloadingEnabled to work
--XX:+UseConcMarkSweepGC
+-XX:+UseParallelGC

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,1 +1,2 @@
+version = "2.3.2"
 maxColumn = 100

--- a/core/src/main/scala/cats/mtl/MonadState.scala
+++ b/core/src/main/scala/cats/mtl/MonadState.scala
@@ -36,11 +36,11 @@ package mtl
 trait MonadState[F[_], S] extends Serializable {
   val monad: Monad[F]
 
+  def state[A](f: S => (S, A)): F[A]
+
   def get: F[S]
 
   def set(s: S): F[Unit]
-
-  def state[A](f: S => (S, A)): F[A]
 
   def inspect[A](f: S => A): F[A]
 
@@ -76,10 +76,8 @@ object MonadState {
 
 
 trait DefaultMonadState[F[_], S] extends MonadState[F, S] {
-
-  def inspect[A](f: S => A): F[A] = monad.map(get)(f)
-
+  def get: F[S] = state(s => (s, s))
   def set(s: S): F[Unit] = state(_ => (s, ()))
-
-  def modify(f: S => S): F[Unit] = monad.flatMap(inspect(f))(set)
+  def inspect[A](f: S => A): F[A] = state(s => (s, f(s)))
+  def modify(f: S => S): F[Unit] = state(s => (f(s), ()))
 }

--- a/core/src/main/scala/cats/mtl/MonadState.scala
+++ b/core/src/main/scala/cats/mtl/MonadState.scala
@@ -52,7 +52,6 @@ trait MonadState[F[_], S] extends Serializable {
   def modify(f: S => S): F[Unit]
 }
 
-
 object MonadState {
   def get[F[_], S](implicit ev: MonadState[F, S]): F[S] =
     ev.get
@@ -78,7 +77,6 @@ object MonadState {
 
   def apply[F[_], S](implicit monadState: MonadState[F, S]): MonadState[F, S] = monadState
 }
-
 
 trait DefaultMonadState[F[_], S] extends MonadState[F, S] {
   def get: F[S] = state(s => (s, s))

--- a/core/src/main/scala/cats/mtl/MonadState.scala
+++ b/core/src/main/scala/cats/mtl/MonadState.scala
@@ -22,12 +22,8 @@ package mtl
   * }
   * }}}
   *
-  * `MonadState` has five internal laws:
+  * `MonadState` has three internal laws:
   * {{{
-  * def modifyIsGetThenSet(f: S => S) = {
-  *   modify(f) <-> (inspect(f) flatMap set)
-  * }
-  *
   * def setIsStateUnit(s: S) = {
   *  set(s) <-> state(_ => (s, ()))
   * }
@@ -38,10 +34,6 @@ package mtl
   *
   * def modifyIsState(f: S => S) = {
   *   modify(f) <-> state(s => (f(s), ()))
-  * }
-  *
-  * def stateIsGetAndModify[A](f: S => (S, A)) = {
-  *   state(f) <-> (get.map(old => f(old)._2) <* modify(old => f(old)._1))
   * }
   * }}}
   *

--- a/core/src/main/scala/cats/mtl/MonadState.scala
+++ b/core/src/main/scala/cats/mtl/MonadState.scala
@@ -7,10 +7,11 @@ package mtl
   *
   * MonadState has four external laws:
   * {{{
+  *
   * def getThenSetDoesNothing = {
   *   get >>= set <-> pure(())
   * }
-  * def setThenGetReturnsSetted(s: S) = {
+  * def setThenGetReturnsSet(s: S) = {
   *   set(s) *> get <-> set(s) *> pure(s)
   * }
   * def setThenSetSetsLast(s1: S, s2: S) = {
@@ -21,14 +22,26 @@ package mtl
   * }
   * }}}
   *
-  * `MonadState` has two internal law:
+  * `MonadState` has five internal laws:
   * {{{
   * def modifyIsGetThenSet(f: S => S) = {
   *   modify(f) <-> (inspect(f) flatMap set)
   * }
   *
-  * def inspectLaw[A](f: S => A) = {
-  *   inspect(f) <-> (get map f)
+  * def setIsStateUnit(s: S) = {
+  *  set(s) <-> state(_ => (s, ()))
+  * }
+
+  * def inpectIsState[A](f: S => A) = {
+  *   inspect(f) <-> state(s => (s, f(s)))
+  * }
+  *
+  * def modifyIsState(f: S => S) = {
+  *   modify(f) <-> state(s => (f(s), ()))
+  * }
+  *
+  * def stateIsGetAndModify[A](f: S => (S, A)) = {
+  *   state(f) <-> (get.map(old => f(old)._2) <* modify(old => f(old)._1))
   * }
   * }}}
   *

--- a/laws/src/main/scala/cats/mtl/laws/MonadStateLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/MonadStateLaws.scala
@@ -4,7 +4,6 @@ package laws
 
 import cats.laws.IsEq
 import cats.laws.IsEqArrow
-import cats.syntax.functor._
 import cats.syntax.flatMap._
 import cats.syntax.apply._
 
@@ -33,10 +32,6 @@ trait MonadStateLaws[F[_], S] {
   }
 
   // internal laws:
-  def modifyIsGetThenSet(f: S => S): IsEq[F[Unit]] = {
-    modify(f) <-> ((get map f) flatMap set)
-  }
-
   def setIsStateUnit(s: S): IsEq[F[Unit]] = {
     set(s) <-> state(_ => (s, ()))
   }
@@ -47,10 +42,6 @@ trait MonadStateLaws[F[_], S] {
 
   def modifyIsState(f: S => S): IsEq[F[Unit]] = {
     modify(f) <-> state(s => (f(s), ()))
-  }
-
-  def stateIsGetAndModify[A](f: S => (S, A)): IsEq[F[A]] = {
-    state(f) <-> (get.map(old => f(old)._2) <* modify(old => f(old)._1))
   }
 }
 

--- a/laws/src/main/scala/cats/mtl/laws/MonadStateLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/MonadStateLaws.scala
@@ -20,7 +20,7 @@ trait MonadStateLaws[F[_], S] {
     (get >>= set) <-> pure(())
   }
 
-  def setThenGetReturnsSetted(s: S): IsEq[F[S]] = {
+  def setThenGetReturnsSet(s: S): IsEq[F[S]] = {
     (set(s) *> get) <-> (set(s) *> pure(s))
   }
 
@@ -32,9 +32,25 @@ trait MonadStateLaws[F[_], S] {
     get *> get <-> get
   }
 
-  // internal law:
+  // internal laws:
   def modifyIsGetThenSet(f: S => S): IsEq[F[Unit]] = {
     modify(f) <-> ((get map f) flatMap set)
+  }
+
+  def setIsStateUnit(s: S): IsEq[F[Unit]] = {
+    set(s) <-> state(_ => (s, ()))
+  }
+
+  def inpectIsState[A](f: S => A): IsEq[F[A]] = {
+    inspect(f) <-> state(s => (s, f(s)))
+  }
+
+  def modifyIsState(f: S => S): IsEq[F[Unit]] = {
+    modify(f) <-> state(s => (f(s), ()))
+  }
+
+  def stateIsGetAndModify[A](f: S => (S, A)): IsEq[F[A]] = {
+    state(f) <-> (get.map(old => f(old)._2) <* modify(old => f(old)._1))
   }
 }
 

--- a/laws/src/main/scala/cats/mtl/laws/discipline/MonadStateTests.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/MonadStateTests.scala
@@ -28,11 +28,9 @@ trait MonadStateTests[F[_], S] extends Laws {
       "set then get returns the set value" -> ∀(laws.setThenGetReturnsSet _),
       "set then set sets the last value" -> ∀(laws.setThenSetSetsLast _),
       "get then get gets once" -> laws.getThenGetGetsOnce,
-      "modify is get then set" -> ∀(laws.modifyIsGetThenSet _),
       "set is state(unit)" -> ∀(laws.setIsStateUnit _),
       "inspect is state" -> ∀(laws.inpectIsState[A] _),
-      "modify is state" -> ∀(laws.modifyIsState _),
-      "stateIsGetAndModify" -> ∀(laws.stateIsGetAndModify[A] _)
+      "modify is state" -> ∀(laws.modifyIsState _)
     )
   }
 

--- a/laws/src/main/scala/cats/mtl/laws/discipline/MonadStateTests.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/MonadStateTests.scala
@@ -18,16 +18,21 @@ trait MonadStateTests[F[_], S] extends Laws {
                                ArbS: Arbitrary[S],
                                CogenS: Cogen[S],
                                EqFU: Eq[F[Unit]],
-                               EqFS: Eq[F[S]]
+                               EqFS: Eq[F[S]],
+                               EqFA: Eq[F[A]]
                               ): RuleSet = {
     new DefaultRuleSet(
       name = "monadState",
       parent = None,
       "get then set has does nothing" -> laws.getThenSetDoesNothing,
-      "set then get returns the setted value" -> ∀(laws.setThenGetReturnsSetted _),
+      "set then get returns the set value" -> ∀(laws.setThenGetReturnsSet _),
       "set then set sets the last value" -> ∀(laws.setThenSetSetsLast _),
       "get then get gets once" -> laws.getThenGetGetsOnce,
-      "modify is get then set" -> ∀(laws.modifyIsGetThenSet _)
+      "modify is get then set" -> ∀(laws.modifyIsGetThenSet _),
+      "set is state(unit)" -> ∀(laws.setIsStateUnit _),
+      "inspect is state" -> ∀(laws.inpectIsState[A] _),
+      "modify is state" -> ∀(laws.modifyIsState _),
+      "stateIsGetAndModify" -> ∀(laws.stateIsGetAndModify[A] _)
     )
   }
 

--- a/tests/src/test/scala/cats/mtl/tests/DefaultImplementationTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/DefaultImplementationTests.scala
@@ -45,9 +45,6 @@ class ApplicativeCensorDefaultTests extends StateTTestsBase {
 class MonadStateDefaultTests extends StateTTestsBase {
   val defaultListMonadState: MonadState[StateC[String]#l, String] = new DefaultMonadState[StateC[String]#l, String] {
     val monad: Monad[StateC[String]#l] = implicitly
-
-    def get: StateC[String]#l[String] = State.get
-
     def state[A](f: String => (String, A)): State[String, A] = State(f)
   }
 

--- a/tests/src/test/scala/cats/mtl/tests/DefaultImplementationTests.scala
+++ b/tests/src/test/scala/cats/mtl/tests/DefaultImplementationTests.scala
@@ -44,12 +44,11 @@ class ApplicativeCensorDefaultTests extends StateTTestsBase {
 
 class MonadStateDefaultTests extends StateTTestsBase {
   val defaultListMonadState: MonadState[StateC[String]#l, String] = new DefaultMonadState[StateC[String]#l, String] {
-
     val monad: Monad[StateC[String]#l] = implicitly
 
     def get: StateC[String]#l[String] = State.get
 
-    def set(s: String): State[String, Unit] = State.set(s)
+    def state[A](f: String => (String, A)): State[String, A] = State(f)
   }
 
   checkAll("State[String, ?]",


### PR DESCRIPTION
It has been mentioned on Gitter that such a function would be useful, especially for things like Ref that provide an atomic modify operation that allows returning a value depending on the previous state. Here it is.

It probably needs some laws, so I'll think about it and report back when I come up with something reasonable (will check what it looks like in Haskell world too).