### PR TITLE
Update README.md version to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ without implicit ambiguity, unlike in pre-1.0.0 cats or Scalaz 7.
 ## Usage
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-mtl-core" % "0.4.0"
+libraryDependencies += "org.typelevel" %% "cats-mtl-core" % "0.5.0"
 ```
 
 If your project uses Scala.js, replace the double-`%` with a triple.  Note that **cats-mtl** has an upstream dependency on **cats-core** version 1.x.
@@ -33,7 +33,7 @@ If you're not sure where to start or what Cats-mtl even is, please refer to the 
 The **cats-mtl-laws** artifact provides [Discipline-style](https://github.com/typelevel/discipline) laws for all of the type classes defined in cats-mtl. It is relatively easy to use these laws to test your own implementations of these typeclasses. Take a look [here](https://github.com/typelevel/cats-mtl/tree/master/laws/src/main/scala/cats/mtl/laws) for more.
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-mtl-laws" % "0.4.0" % Test
+libraryDependencies += "org.typelevel" %% "cats-mtl-laws" % "0.5.0" % Test
 ```
 
 These laws are compatible with both Specs2 and ScalaTest.


### PR DESCRIPTION
I couldn't see any reason why the version in the `usage` section of the readme was set to `0.4.0` for both packages. 

I've been blindly following the readme and using an older version. I only spotted this as `meow-mtl` uses `0.5.0`, so it would be nice to suggest the latest version (unless there's a reason to avoid 0.5.0.)

