### PR TITLE
Update discipline-scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -196,7 +196,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform)
   .settings(coreSettings: _*)
   .settings(
     libraryDependencies ++= Seq("org.typelevel" %%% "cats-testkit" % catsVersion,
-                                "org.typelevel" %%% "discipline-scalatest" % "1.0.0-RC2")
+                                "org.typelevel" %%% "discipline-scalatest" % "1.0.0-RC4")
   )
   .settings(Publishing.noPublishSettings: _*)
   .jsSettings(commonJsSettings: _*)

--- a/tests/src/test/scala/cats/mtl/tests/BaseSuite.scala
+++ b/tests/src/test/scala/cats/mtl/tests/BaseSuite.scala
@@ -11,14 +11,14 @@ import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}
 import org.scalatest.prop.Configuration
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite.AnyFunSuite
-import org.typelevel.discipline.scalatest.Discipline
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 abstract class BaseSuite extends AnyFunSuite
   with Matchers
   with Configuration
   with StrictCatsEquality
   with EqSyntax
-  with Discipline {
+  with FunSuiteDiscipline {
 
   implicit def catsMtlLawsExhaustiveCheckForArbitrary[A: Arbitrary]: ExhaustiveCheck[A] =
     ExhaustiveCheck.instance(Gen.resize(30, Arbitrary.arbitrary[List[A]]).sample.get)


### PR DESCRIPTION
Supersedes #184, which fails because there is a breaking change in this RC.