### PR TITLE
move Local instances into Ask companion

### DIFF
--- a/core/src/main/scala-2.12/cats/mtl/LowPriorityApplicativeAskInstancesCompat.scala
+++ b/core/src/main/scala-2.12/cats/mtl/LowPriorityApplicativeAskInstancesCompat.scala
@@ -20,7 +20,7 @@ import cats.{Applicative, Id}
 import cats.data.{Kleisli, Reader}
 
 private[mtl] trait LowPriorityAskInstancesCompat {
-  implicit def askForReader[E]: Ask[Reader[E, *], E] =
+  def askForReader[E]: Ask[Reader[E, *], E] =
     new Ask[Reader[E, *], E] {
       val applicative = Applicative[Reader[E, *]]
       def ask[E2 >: E] = Kleisli.ask[Id, E2]

--- a/core/src/main/scala/cats/mtl/Ask.scala
+++ b/core/src/main/scala/cats/mtl/Ask.scala
@@ -60,7 +60,7 @@ private[mtl] trait AskForMonadPartialOrder[F[_], G[_], E] extends Ask[G, E] {
 
 private[mtl] trait LowPriorityAskInstances extends LowPriorityAskInstancesCompat {
 
-  implicit def askForMonadPartialOrder[F[_], G[_], E](
+  def askForMonadPartialOrder[F[_], G[_], E](
       implicit lift0: MonadPartialOrder[F, G],
       F0: Ask[F, E]): Ask[G, E] =
     new AskForMonadPartialOrder[F, G, E] {
@@ -69,15 +69,15 @@ private[mtl] trait LowPriorityAskInstances extends LowPriorityAskInstancesCompat
     }
 }
 
-private[mtl] trait AskInstances extends LowPriorityAskInstances {
+private[mtl] trait AskInstances extends LocalInstances with LowPriorityAskInstances {
 
-  implicit def askForKleisli[F[_], E](implicit F: Applicative[F]): Ask[Kleisli[F, E, *], E] =
-    Local.baseLocalForKleisli[F, E]
+  def askForKleisli[F[_], E](implicit F: Applicative[F]): Ask[Kleisli[F, E, *], E] =
+    baseLocalForKleisli[F, E]
 
-  implicit def askForRWST[F[_], E, L, S](
+  def askForRWST[F[_], E, L, S](
       implicit F: Monad[F],
       L: Monoid[L]): Ask[RWST[F, E, L, S, *], E] =
-    Local.baseLocalForRWST[F, E, L, S]
+    baseLocalForRWST[F, E, L, S]
 }
 
 object Ask extends AskInstances {

--- a/core/src/main/scala/cats/mtl/Local.scala
+++ b/core/src/main/scala/cats/mtl/Local.scala
@@ -162,7 +162,7 @@ private[mtl] trait LocalInstances extends LowPriorityLocalInstances {
     }
 }
 
-object Local extends LocalInstances {
+object Local {
   def apply[F[_], A](implicit local: Local[F, A]): Local[F, A] = local
 
   def local[F[_], E, A](fa: F[A])(f: E => E)(implicit local: Local[F, E]): F[A] =


### PR DESCRIPTION
Follows https://github.com/typelevel/cats/pull/3043, moves typeclass instances from `Local` to `Ask` companion.