### PR TITLE
Replace actions/setup-ruby with ruby/setup-ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ ThisBuild / crossScalaVersions := Seq("3.0.0-M2", "3.0.0-M3", "2.12.12", Scala21
 
 ThisBuild / githubWorkflowBuildPreamble ++= Seq(
   WorkflowStep.Use(
-    "actions",
+    "ruby",
     "setup-ruby",
     "v1",
     name = Some("Setup Ruby"),


### PR DESCRIPTION
See: https://github.com/typelevel/cats/pull/3767

While cats-mtl seems to not be running into the same problems as the main cats microsite build, it will be good to move away from the old action to the new officially supported action for setting up ruby.