### PR TITLE
Add unidocs to root aggregate

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val commonNativeSettings = Seq(
 
 val CatsVersion = "2.8.0"
 
-lazy val root = tlCrossRootProject.aggregate(core, laws, tests)
+lazy val root = tlCrossRootProject.aggregate(core, laws, tests, unidocs)
 
 lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)


### PR DESCRIPTION
The `cats-mtl-docs` artifact generated by the `unidocs` module is not being published because the `unidocs` module is not part of the root aggregate.

The `cats-mtl-docs` unified documentation should now be published and viewable with javadoc.io, which will fix the broken links discovered by #440.