### PR TITLE
implement Cats typeclass instances for Ask and Local

### DIFF
--- a/core/src/main/scala/cats/mtl/Ask.scala
+++ b/core/src/main/scala/cats/mtl/Ask.scala
@@ -18,6 +18,8 @@ package cats
 package mtl
 
 import cats.data.{Kleisli, ReaderWriterStateT => RWST}
+import cats.mtl.Ask.{const, AskImpl}
+import cats.syntax.all._
 
 import scala.annotation.implicitNotFound
 
@@ -67,6 +69,14 @@ private[mtl] trait LowPriorityAskInstances extends LowPriorityAskInstancesCompat
       val lift: MonadPartialOrder[F, G] = lift0
       val F: Ask[F, E] = F0
     }
+
+  implicit def applicativeAsk[F[_]: Applicative]: Applicative[Ask[F, *]] =
+    new Applicative[Ask[F, *]] {
+      override def pure[A](x: A): Ask[F, A] = const[F, A](x)
+
+      override def ap[A, B](ff: Ask[F, A => B])(fa: Ask[F, A]): Ask[F, B] =
+        new AskImpl(ff.applicative.ap(ff.ask)(fa.ask).widen)
+    }
 }
 
 private[mtl] trait AskInstances extends LowPriorityAskInstances {
@@ -78,6 +88,17 @@ private[mtl] trait AskInstances extends LowPriorityAskInstances {
       implicit F: Monad[F],
       L: Monoid[L]): Ask[RWST[F, E, L, S, *], E] =
     Local.baseLocalForRWST[F, E, L, S]
+
+  implicit def monadAsk[F[_]: Monad]: Monad[Ask[F, *]] = new Monad[Ask[F, *]] {
+    override def flatMap[A, B](fa: Ask[F, A])(f: A => Ask[F, B]): Ask[F, B] = new AskImpl(
+      fa.ask.flatMap(f(_).ask))
+
+    override def tailRecM[A, B](a: A)(f: A => Ask[F, Either[A, B]]): Ask[F, B] = new AskImpl(
+      Monad[F].tailRecM(a)(f(_).ask))
+
+    override def pure[A](x: A): Ask[F, A] = const[F, A](x)
+  }
+
 }
 
 object Ask extends AskInstances {
@@ -113,4 +134,8 @@ object Ask extends AskInstances {
   def reader[F[_], E, A](fun: E => A)(implicit ask: Ask[F, E]): F[A] =
     ask.reader(fun)
 
+  @inline final private[mtl] class AskImpl[F[_]: Applicative, A](fa: F[A]) extends Ask[F, A] {
+    override def applicative: Applicative[F] = implicitly
+    override def ask[E2 >: A]: F[E2] = fa.widen
+  }
 }

--- a/tests/shared/src/test/scala/cats/mtl/tests/AskCatsInstanceTests.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/AskCatsInstanceTests.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+package tests
+
+import cats.laws.discipline.{ApplicativeTests, MonadTests}
+import org.scalacheck.Arbitrary._
+import org.scalacheck._
+
+class AskCatsInstanceTests extends BaseSuite {
+
+  private implicit def arbAsk[F[_]: Applicative, A: Arbitrary]: Arbitrary[Ask[F, A]] =
+    Arbitrary {
+      arbitrary[A].map(Ask.const[F, A](_))
+    }
+
+  private implicit def eqAsk[F[_], A](implicit E: Eq[F[A]]): Eq[Ask[F, A]] = Eq.by(_.ask)
+
+  checkAll(
+    "Applicative[Ask[Option, *]]",
+    ApplicativeTests[Ask[Option, *]](
+      Ask.applicativeAsk[Option] // make sure we test the weaker applicative instance
+    ).applicative[String, String, String]
+  )
+
+  checkAll("Monad[Ask[Option, *]]", MonadTests[Ask[Option, *]].monad[String, String, String])
+
+}

--- a/tests/shared/src/test/scala/cats/mtl/tests/LocalCatsInstanceTests.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/LocalCatsInstanceTests.scala
@@ -21,7 +21,7 @@ package tests
 import cats.data._
 import cats.laws.discipline.InvariantTests
 import cats.laws.discipline.eq._
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary._
 
 class LocalCatsInstanceTests extends BaseSuite {
@@ -29,17 +29,9 @@ class LocalCatsInstanceTests extends BaseSuite {
       implicit ev: Eq[F[B]]): Eq[Kleisli[F, A, B]] =
     Eq.by((x: Kleisli[F, A, B]) => x.run)
 
-  private implicit def arbLocalReader[F[_]: Monad, AA: Arbitrary]
-      : Arbitrary[Local[Kleisli[F, AA, *], AA]] = Arbitrary {
-    arbitrary[AA].map { a =>
-      new Local[Kleisli[F, AA, *], AA] {
-        override def local[A](fa: Kleisli[F, AA, A])(f: AA => AA): Kleisli[F, AA, A] =
-          fa.local(f)
-        override def applicative: Applicative[Kleisli[F, AA, *]] = implicitly
-        override def ask[E2 >: AA]: Kleisli[F, AA, E2] = Kleisli.pure(a)
-      }
-    }
-  }
+  private implicit def arbLocalReader[F[_]: Monad, AA]
+      : Arbitrary[Local[Kleisli[F, AA, *], AA]] =
+    Arbitrary(Gen.const(Local.baseLocalForKleisli))
 
   private implicit def eqLocal[F[_], A](implicit E: Eq[F[A]]): Eq[Local[F, A]] = Eq.by(_.ask)
 

--- a/tests/shared/src/test/scala/cats/mtl/tests/LocalCatsInstanceTests.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/LocalCatsInstanceTests.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+package tests
+
+import cats.data._
+import cats.laws.discipline.InvariantTests
+import cats.laws.discipline.eq._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+
+class LocalCatsInstanceTests extends BaseSuite {
+  private implicit def eqKleisli[F[_], A: Arbitrary, B](
+      implicit ev: Eq[F[B]]): Eq[Kleisli[F, A, B]] =
+    Eq.by((x: Kleisli[F, A, B]) => x.run)
+
+  private implicit def arbLocalReader[F[_]: Monad, AA: Arbitrary]
+      : Arbitrary[Local[Kleisli[F, AA, *], AA]] = Arbitrary {
+    arbitrary[AA].map { a =>
+      new Local[Kleisli[F, AA, *], AA] {
+        override def local[A](fa: Kleisli[F, AA, A])(f: AA => AA): Kleisli[F, AA, A] =
+          fa.local(f)
+        override def applicative: Applicative[Kleisli[F, AA, *]] = implicitly
+        override def ask[E2 >: AA]: Kleisli[F, AA, E2] = Kleisli.pure(a)
+      }
+    }
+  }
+
+  private implicit def eqLocal[F[_], A](implicit E: Eq[F[A]]): Eq[Local[F, A]] = Eq.by(_.ask)
+
+  checkAll(
+    "Invariant[Local[Kleisli[Option, String, *], *]]",
+    InvariantTests[Local[Kleisli[Option, String, *], *]].invariant[String, Int, String])
+
+}

--- a/tests/shared/src/test/scala/cats/mtl/tests/ReaderTTests.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/ReaderTTests.scala
@@ -24,6 +24,8 @@ import cats.laws.discipline.SerializableTests
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import cats.mtl.laws.discipline._
+import cats.syntax.all._
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._
 
 class ReaderTTests extends BaseSuite {
@@ -49,6 +51,14 @@ class ReaderTTests extends BaseSuite {
       F: FlatMap[F]): Eq[StateT[F, S, A]] =
     Eq.by[StateT[F, S, A], S => F[(S, A)]](state => s => state.run(s))
 
+  private implicit def stringToStringWrapper[F[_]](
+      implicit L: Local[F, String]): Local[F, StringWrapper] =
+    L.imap(StringWrapper(_))(_.value)
+
+  private implicit def stringWrapperToString[F[_]](
+      implicit L: Local[F, StringWrapper]): Local[F, String] =
+    L.imap(_.value)(StringWrapper(_))
+
   {
     Applicative[Reader[String, *]]
     checkAll(
@@ -57,6 +67,14 @@ class ReaderTTests extends BaseSuite {
     checkAll(
       "Local[Kleisli[Id, String, *], String]",
       SerializableTests.serializable(Local[Kleisli[Id, String, *], String]))
+
+    checkAll(
+      "Local[Reader[String, *], String].imap",
+      LocalTests[Reader[String, *], StringWrapper].local[String, String]
+    )
+    checkAll(
+      "Local[Reader[String, *], StringWrapper]",
+      SerializableTests.serializable(Local[Reader[String, *], StringWrapper]))
   }
 
   {
@@ -66,6 +84,14 @@ class ReaderTTests extends BaseSuite {
     checkAll(
       "Local[ReaderTC[Option, String]#l, String]",
       SerializableTests.serializable(Local[ReaderTC[Option, String]#l, String]))
+
+    checkAll(
+      "LocalReaderT[Option, String, *].imap",
+      LocalTests[ReaderTC[Option, String]#l, StringWrapper].local[String, String]
+    )
+    checkAll(
+      "Local[ReaderTC[Option, String]#l, StringWrapper]",
+      SerializableTests.serializable(Local[ReaderTC[Option, String]#l, StringWrapper]))
   }
 
   {
@@ -80,11 +106,31 @@ class ReaderTTests extends BaseSuite {
       )
 
       checkAll(
+        "ReaderT[ReaderT[Option, StringWrapper, *], Int, String].imap",
+        LocalTests[ReaderT[ReaderT[Option, StringWrapper, *], Int, *], String]
+          .local[String, String])
+      checkAll(
+        "Local[ReaderT[ReaderT[Option, StringWrapper, *], Int, *], StringWrapper]",
+        SerializableTests.serializable(
+          Local[ReaderT[ReaderT[Option, StringWrapper, *], Int, *], String])
+      )
+
+      checkAll(
         "StateT[ReaderT[Option, String, *], Int, *]",
         LocalTests[StateTIntOverReaderTStringOverOption, String].local[String, String])
       checkAll(
-        "Local[StateTIntOverReaderTStringOverOption, String]",
+        "Local[StateT[ReaderT[Option, String, *], Int, *], String]",
         SerializableTests.serializable(Local[StateTIntOverReaderTStringOverOption, String])
+      )
+
+      checkAll(
+        "StateT[ReaderT[Option, String, *], Int, *].imap",
+        LocalTests[StateT[ReaderT[Option, StringWrapper, *], Int, *], String]
+          .local[String, String])
+      checkAll(
+        "Local[StateT[ReaderT[Option, StringWrapper, *], Int, *], String].imap",
+        SerializableTests.serializable(
+          Local[StateT[ReaderT[Option, StringWrapper, *], Int, *], String])
       )
     }
 
@@ -97,11 +143,30 @@ class ReaderTTests extends BaseSuite {
     )
 
     checkAll(
+      "WriterT[ReaderT[Option, String, *], Int, *].imap",
+      LocalTests[WriterT[ReaderT[Option, StringWrapper, *], Int, *], String]
+        .local[String, String])
+    checkAll(
+      "Local[WriterTIntOverReaderTStringOverOption, StringWrapper].imap",
+      SerializableTests.serializable(
+        Local[WriterT[ReaderT[Option, StringWrapper, *], Int, *], String])
+    )
+
+    checkAll(
       "OptionT[ReaderT[Option, String, *], *]",
       LocalTests[OptionTOverReaderTStringOverOption, String].local[String, String])
     checkAll(
       "Local[OptionTOverReaderTStringOverOption, String]",
       SerializableTests.serializable(Local[OptionTOverReaderTStringOverOption, String])
+    )
+
+    checkAll(
+      "OptionT[ReaderT[Option, StringWrapper, *], *]",
+      LocalTests[OptionT[ReaderT[Option, StringWrapper, *], *], String].local[String, String])
+    checkAll(
+      "Local[OptionT[ReaderT[Option, StringWrapper, *], *], String]",
+      SerializableTests.serializable(
+        Local[OptionT[ReaderT[Option, StringWrapper, *], *], String])
     )
 
     checkAll(
@@ -112,6 +177,27 @@ class ReaderTTests extends BaseSuite {
       SerializableTests.serializable(Local[EitherTIntOverReaderTStringOverOption, String])
     )
 
+    checkAll(
+      "EitherT[ReaderT[Option, StringWrapper, *], String, *]",
+      LocalTests[EitherT[ReaderT[Option, StringWrapper, *], String, *], String]
+        .local[String, String])
+    checkAll(
+      "Local[EitherT[ReaderT[Option, StringWrapper, *], String, *], String]",
+      SerializableTests.serializable(
+        Local[EitherT[ReaderT[Option, StringWrapper, *], String, *], String])
+    )
+
   }
 
+}
+
+/**
+ * Only exists as a type that is trivially isomorphic to `String`
+ */
+case class StringWrapper(value: String)
+object StringWrapper {
+  implicit val stringWrapperEq: Eq[StringWrapper] = Eq.by(_.value)
+  implicit val arbStringWrapper: Arbitrary[StringWrapper] = Arbitrary(
+    arbitrary[String].map(StringWrapper(_)))
+  implicit val cogenStringWrapper: Cogen[StringWrapper] = Cogen[String].contramap(_.value)
 }

--- a/tests/shared/src/test/scala/cats/mtl/tests/ReaderTTests.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/ReaderTTests.scala
@@ -55,7 +55,7 @@ class ReaderTTests extends BaseSuite {
       "Reader[String, *]",
       LocalTests[Kleisli[Id, String, *], String].local[String, String])
     checkAll(
-      "FunctorLocal[Reader[String, *], String]",
+      "Local[Kleisli[Id, String, *], String]",
       SerializableTests.serializable(Local[Kleisli[Id, String, *], String]))
   }
 
@@ -64,7 +64,7 @@ class ReaderTTests extends BaseSuite {
       "ReaderT[Option, String, *]",
       LocalTests[ReaderTC[Option, String]#l, String].local[String, String])
     checkAll(
-      "FunctorLocal[ReaderT[Option, String, *], String]",
+      "Local[ReaderTC[Option, String]#l, String]",
       SerializableTests.serializable(Local[ReaderTC[Option, String]#l, String]))
   }
 
@@ -75,7 +75,7 @@ class ReaderTTests extends BaseSuite {
         "ReaderT[ReaderT[Option, String, *], Int, *]",
         LocalTests[ReaderTIntOverReaderTStringOverOption, String].local[String, String])
       checkAll(
-        "FunctorLocal[ReaderT[ReaderT[Option, String, *], Int, *], String]",
+        "Local[ReaderTIntOverReaderTStringOverOption, String]",
         SerializableTests.serializable(Local[ReaderTIntOverReaderTStringOverOption, String])
       )
 
@@ -83,7 +83,7 @@ class ReaderTTests extends BaseSuite {
         "StateT[ReaderT[Option, String, *], Int, *]",
         LocalTests[StateTIntOverReaderTStringOverOption, String].local[String, String])
       checkAll(
-        "FunctorLocal[StateT[ReaderT[Option, String, *], Int, *], String]",
+        "Local[StateTIntOverReaderTStringOverOption, String]",
         SerializableTests.serializable(Local[StateTIntOverReaderTStringOverOption, String])
       )
     }
@@ -92,7 +92,7 @@ class ReaderTTests extends BaseSuite {
       "WriterT[ReaderT[Option, String, *], Int, *]",
       LocalTests[WriterTIntOverReaderTStringOverOption, String].local[String, String])
     checkAll(
-      "FunctorLocal[WriterT[ReaderT[Option, String, *], Int, *], String]",
+      "Local[WriterTIntOverReaderTStringOverOption, String]",
       SerializableTests.serializable(Local[WriterTIntOverReaderTStringOverOption, String])
     )
 
@@ -100,7 +100,7 @@ class ReaderTTests extends BaseSuite {
       "OptionT[ReaderT[Option, String, *], *]",
       LocalTests[OptionTOverReaderTStringOverOption, String].local[String, String])
     checkAll(
-      "FunctorLocal[OptionT[ReaderT[Option, String, *], *], String]",
+      "Local[OptionTOverReaderTStringOverOption, String]",
       SerializableTests.serializable(Local[OptionTOverReaderTStringOverOption, String])
     )
 
@@ -108,7 +108,7 @@ class ReaderTTests extends BaseSuite {
       "EitherT[ReaderT[Option, String, *], String, *]",
       LocalTests[EitherTIntOverReaderTStringOverOption, String].local[String, String])
     checkAll(
-      "FunctorLocal[EitherT[ReaderT[Option, String, *], Int, *], String]",
+      "Local[EitherTIntOverReaderTStringOverOption, String]",
       SerializableTests.serializable(Local[EitherTIntOverReaderTStringOverOption, String])
     )
 


### PR DESCRIPTION
This lets users `map`/`flatMap` (for `Ask`) or `imap` (for `Local`) the environment of a given instance and make the mapped value available in a new implicit scope. 

This came up for me when trying to provide a `Local[F, natchez.Span[F]]`, where `F[_]` is `Kleisli[IO, Span[IO], *]`. `Local.baseLocalForKleisli` gives us `Local[Kleisli[IO, Span[IO], *], Span[IO]]`, which is not quite the right shape for an app with an `implicit ev: Local[F, Span[F]]` (which becomes `ev: Local[Kleisli[IO, Span[IO], *], Span[Kleisli[IO, Span[IO], *]]]`). In other words, `baseLocalForKleisli` gives us a local environment of `Span[IO]` when we need `Span[Kleisli[IO, Span[IO], *]]`.

Given `Invariant[Local[F, *]]`, we can do 
```scala
Local[Kleisli[IO, Span[IO], *], Span[IO]].imap(Kleisli.liftK)(Kleisli.applyK(NoopSpan()))
```
to get the `Local[Kleisli[IO, Span[IO], *], Span[Kleisli[IO, Span[IO], *]]]` needed for the app.