### PR TITLE
Bump base version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "1.3"
+ThisBuild / tlBaseVersion := "1.4"
 ThisBuild / startYear := Some(2021)
 ThisBuild / developers := List(
   tlGitHubDev("SystemFw", "Fabio Labella"),


### PR DESCRIPTION
This should have happened a while back. Also merges in the v1.3.1 patch.

Closes https://github.com/typelevel/cats-mtl/issues/440.