### PR TITLE
Add `Raise#fromEither` and friends

### DIFF
--- a/core/src/main/scala/cats/mtl/Ask.scala
+++ b/core/src/main/scala/cats/mtl/Ask.scala
@@ -53,6 +53,9 @@ trait Ask[F[_], +E] extends Serializable {
   def reader[A](f: E => A): F[A] = applicative.map(ask)(f)
 
   def fromReader[A](ra: Reader[E, A]): F[A] = reader(ra.run)
+
+  def fromKleisli[A](ka: Kleisli[F, E, A])(implicit F: FlatMap[F]): F[A] =
+    ask.flatMap(ka.run(_))
 }
 
 private[mtl] trait AskForMonadPartialOrder[F[_], G[_], E] extends Ask[G, E] {

--- a/core/src/main/scala/cats/mtl/Ask.scala
+++ b/core/src/main/scala/cats/mtl/Ask.scala
@@ -17,7 +17,7 @@
 package cats
 package mtl
 
-import cats.data.{Kleisli, ReaderWriterStateT => RWST}
+import cats.data.{Kleisli, Reader, ReaderWriterStateT => RWST}
 import cats.mtl.Ask.{const, AskImpl}
 import cats.syntax.all._
 
@@ -51,6 +51,8 @@ trait Ask[F[_], +E] extends Serializable {
   def ask[E2 >: E]: F[E2]
 
   def reader[A](f: E => A): F[A] = applicative.map(ask)(f)
+
+  def fromReader[A](ra: Reader[E, A]): F[A] = reader(ra.run)
 }
 
 private[mtl] trait AskForMonadPartialOrder[F[_], G[_], E] extends Ask[G, E] {

--- a/core/src/main/scala/cats/mtl/Raise.scala
+++ b/core/src/main/scala/cats/mtl/Raise.scala
@@ -79,6 +79,10 @@ trait Raise[F[_], -E] extends Serializable {
   def ensure[E2 <: E, A](fa: F[A])(error: => E2)(predicate: A => Boolean)(
       implicit A: Monad[F]): F[A] =
     A.flatMap(fa)(a => if (predicate(a)) A.pure(a) else raise(error))
+
+  def fromEither[A](ea: Either[E, A])(implicit F: Applicative[F]): F[A] =
+    ea.fold(raise, F.pure)
+
 }
 
 private[mtl] trait RaiseMonadPartialOrder[F[_], G[_], E] extends Raise[G, E] {

--- a/core/src/main/scala/cats/mtl/Raise.scala
+++ b/core/src/main/scala/cats/mtl/Raise.scala
@@ -83,6 +83,9 @@ trait Raise[F[_], -E] extends Serializable {
   def fromEither[A](ea: Either[E, A])(implicit F: Applicative[F]): F[A] =
     ea.fold(raise, F.pure)
 
+  def fromEitherT[E2 <: E, A](ea: EitherT[F, E2, A])(implicit F: Monad[F]): F[A] =
+    F.flatMap(ea.value)(fromEither(_))
+
 }
 
 private[mtl] trait RaiseMonadPartialOrder[F[_], G[_], E] extends Raise[G, E] {

--- a/core/src/main/scala/cats/mtl/Raise.scala
+++ b/core/src/main/scala/cats/mtl/Raise.scala
@@ -86,6 +86,12 @@ trait Raise[F[_], -E] extends Serializable {
   def fromEitherT[E2 <: E, A](ea: EitherT[F, E2, A])(implicit F: Monad[F]): F[A] =
     F.flatMap(ea.value)(fromEither(_))
 
+  def fromOption[E2 <: E, A](oa: Option[A])(e: => E2)(implicit F: Applicative[F]): F[A] =
+    oa.fold[F[A]](raise(e))(F.pure)
+
+  def fromOptionT[E2 <: E, A](ota: OptionT[F, A])(e: => E2)(implicit F: Monad[F]): F[A] =
+    F.flatMap(ota.value)(oa => fromOption(oa)(e))
+
 }
 
 private[mtl] trait RaiseMonadPartialOrder[F[_], G[_], E] extends Raise[G, E] {

--- a/core/src/main/scala/cats/mtl/Stateful.scala
+++ b/core/src/main/scala/cats/mtl/Stateful.scala
@@ -70,6 +70,13 @@ trait Stateful[F[_], S] extends Serializable {
       val (s1, a) = state.run(s0).value
       monad.as(set(s1), a)
     }
+
+  def fromStateT[A](state: StateT[F, S, A]): F[A] =
+    monad.flatMap(get) { s0 =>
+      monad.flatMap(state.run(s0)(monad)) { case (s1, a) =>
+        monad.as(set(s1), a)
+      }
+    }
 }
 
 private[mtl] trait LowPriorityStatefulInstances {

--- a/core/src/main/scala/cats/mtl/Stateful.scala
+++ b/core/src/main/scala/cats/mtl/Stateful.scala
@@ -17,7 +17,7 @@
 package cats
 package mtl
 
-import cats.data.{ReaderWriterStateT => RWST, StateT}
+import cats.data.{ReaderWriterStateT => RWST, State, StateT}
 
 import scala.annotation.implicitNotFound
 
@@ -64,6 +64,12 @@ trait Stateful[F[_], S] extends Serializable {
   def get: F[S]
 
   def set(s: S): F[Unit]
+
+  def fromState[A](state: State[S, A]): F[A] =
+    monad.flatMap(get) { s0 =>
+      val (s1, a) = state.run(s0).value
+      monad.as(set(s1), a)
+    }
 }
 
 private[mtl] trait LowPriorityStatefulInstances {

--- a/core/src/main/scala/cats/mtl/Tell.scala
+++ b/core/src/main/scala/cats/mtl/Tell.scala
@@ -49,6 +49,9 @@ trait Tell[F[_], -L] extends Serializable {
   def tuple[A](ta: (L, A)): F[A] = writer(ta._2, ta._1)
 
   def fromWriter[L2 <: L, A](wa: Writer[L2, A]): F[A] = tuple(wa.run)
+
+  def fromWriterT[L2 <: L, A](wa: WriterT[F, L2, A])(implicit F: FlatMap[F]): F[A] =
+    F.flatMap(wa.run)(tuple(_))
 }
 
 private[mtl] trait TellMonadPartialOrder[F[_], G[_], L] extends Tell[G, L] {

--- a/core/src/main/scala/cats/mtl/Tell.scala
+++ b/core/src/main/scala/cats/mtl/Tell.scala
@@ -17,7 +17,7 @@
 package cats
 package mtl
 
-import cats.data.{ReaderWriterStateT => RWST, WriterT}
+import cats.data.{ReaderWriterStateT => RWST, Writer, WriterT}
 
 import scala.annotation.implicitNotFound
 
@@ -47,6 +47,8 @@ trait Tell[F[_], -L] extends Serializable {
   def writer[A](a: A, l: L): F[A] = functor.as(tell(l), a)
 
   def tuple[A](ta: (L, A)): F[A] = writer(ta._2, ta._1)
+
+  def fromWriter[L2 <: L, A](wa: Writer[L2, A]): F[A] = tuple(wa.run)
 }
 
 private[mtl] trait TellMonadPartialOrder[F[_], G[_], L] extends Tell[G, L] {


### PR DESCRIPTION
Inspired by discussion with @benhutchison in https://github.com/typelevel/cats-effect/discussions/3765#discussioncomment-6623490. The idea is to add a bunch of methods for lifting from the "primitive" monads `Either`, `Reader`, `Writer`, `State` into `F[_]`. This complements https://github.com/typelevel/cats-mtl/pull/489 which pushes towards using `IO` for `F[_]` instead of the monad transformers `EitherT`, `Kleisli`, `WriterT`, and `StateT`. So we need a mechanism for lifting.

- `Ask#fromReader`
- `Raise#fromEither` (analogous to `ApplicativeError#fromEither`)
- `Stateful#fromState`
- `Tell#fromWriter`