### PR TITLE
Use `cats.syntax.all._` instead of `cats.implicits`

### DIFF
--- a/docs/mtl-classes/chronicle.md
+++ b/docs/mtl-classes/chronicle.md
@@ -46,7 +46,7 @@ We can prohibit bad user data by using a computation halting `confess` and nudge
 ```scala mdoc
 import cats.Monad
 import cats.data._
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Chronicle
 
 type Failures = NonEmptyChain[String]

--- a/docs/mtl-classes/handle.md
+++ b/docs/mtl-classes/handle.md
@@ -17,7 +17,7 @@ Let's look at an example of how to use this function:
 
 ```scala mdoc
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl._
 import cats.mtl.implicits._
 

--- a/docs/mtl-classes/listen.md
+++ b/docs/mtl-classes/listen.md
@@ -11,7 +11,7 @@ Let's have a look at an example of how one could do this:
 ```scala mdoc
 import cats._
 import cats.data._
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl._
 import cats.mtl.implicits._
 

--- a/docs/mtl-classes/local.md
+++ b/docs/mtl-classes/local.md
@@ -18,7 +18,7 @@ Here's a quick example of how it works:
 ```scala mdoc
 import cats._
 import cats.data._
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl._
 
 def calculateContentLength[F[_]: Applicative](implicit F: Ask[F, String]): F[Int] =

--- a/docs/mtl-classes/raise.md
+++ b/docs/mtl-classes/raise.md
@@ -19,7 +19,7 @@ Here's a quick example of how you might use it:
 
 ```scala mdoc
 import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl._
 
 def parseNumber[F[_]: Applicative](in: String)(implicit F: Raise[F, String]): F[Int] = {

--- a/docs/mtl-classes/stateful.md
+++ b/docs/mtl-classes/stateful.md
@@ -23,7 +23,7 @@ Let's say we have the following function to access a service:
 ```scala mdoc
 import cats._
 import cats.data._
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Stateful
 
 case class ServiceResult(id: Int, companies: List[String])

--- a/docs/mtl-classes/tell.md
+++ b/docs/mtl-classes/tell.md
@@ -19,7 +19,7 @@ First we'll add the actual service call with its parameters and result types:
 ```scala mdoc
 import cats._
 import cats.data._
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Tell
 
 case class ServiceParams(option1: String, option2: Int)


### PR DESCRIPTION
similar to https://github.com/typelevel/cats/pull/4394