### PR TITLE
Add `LiftValue` and `LiftKind`

### DIFF
--- a/core/src/main/scala/cats/mtl/LiftKind.scala
+++ b/core/src/main/scala/cats/mtl/LiftKind.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+
+import cats.data._
+
+import scala.annotation.implicitNotFound
+import scala.{unchecked => uc}
+
+/**
+ * Lifts values and scope transformations from the higher-kinded type `F` to the higher-kinded
+ * type `G`.
+ */
+@implicitNotFound("no way defined to lift values and scopes from ${F} to ${G}")
+trait LiftKind[F[_], G[_]] extends LiftValue[F, G] with Serializable {
+
+  /**
+   * Modifies the context of a `G[A]` using the given scope transformation in `F`.
+   *
+   * @note
+   *   This method is usually best implemented by a `mapK` method on `G`.
+   */
+  def limitedMapK[A](ga: G[A])(scope: F ~> F): G[A]
+
+  /**
+   * Lifts a scope transformation in `F` into a scope operation in `G`.
+   *
+   * @note
+   *   Implementors SHOULD NOT override this method; the only reason it is not final is for
+   *   optimization of the identity case.
+   */
+  def liftScope(scope: F ~> F): G ~> G =
+    new (G ~> G) {
+      def apply[A](fa: G[A]): G[A] = limitedMapK(fa)(scope)
+    }
+
+  /** @return an instance that lifts `E` to `F` and then `F` to `G` */
+  def compose[E[_]](that: LiftKind[E, F]): LiftKind[E, G] =
+    LiftKind.Composed(that, this)
+
+  /** @return an instance that lifts `F` to `G` and then `G` to `H` */
+  def andThen[H[_]](that: LiftKind[G, H]): LiftKind[F, H] =
+    LiftKind.Composed(this, that)
+}
+
+object LiftKind extends LowPriorityLiftKindInstances {
+
+  private[this] final class Identity[F[_]: Applicative]
+      extends LiftValue.Identity[F]
+      with LiftKind[F, F] {
+    def limitedMapK[A](ga: F[A])(scope: F ~> F): F[A] = scope(ga)
+    override def liftScope(scope: F ~> F): F ~> F = scope
+  }
+
+  private[this] final class Composed[F[_], G[_], H[_]] private (
+      inner: LiftKind[F, G],
+      outer: LiftKind[G, H]
+  ) extends LiftKind[F, H] {
+    def applicativeF: Applicative[F] = inner.applicativeF
+    def applicativeG: Applicative[H] = outer.applicativeG
+    def apply[A](fa: F[A]): H[A] = outer(inner(fa))
+    def limitedMapK[A](ga: H[A])(scope: F ~> F): H[A] =
+      outer.limitedMapK(ga)(inner.liftScope(scope))
+    override def liftScope(scope: F ~> F): H ~> H =
+      outer.liftScope(inner.liftScope(scope))
+  }
+
+  private object Composed {
+    def apply[F[_], G[_], H[_]](
+        inner: LiftKind[F, G],
+        outer: LiftKind[G, H]
+    ): LiftKind[F, H] =
+      if (inner.isInstanceOf[Identity[F @uc]]) outer.asInstanceOf[LiftKind[F, H]]
+      else if (outer.isInstanceOf[Identity[G @uc]]) inner.asInstanceOf[LiftKind[F, H]]
+      else new Composed(inner, outer)
+  }
+
+  def apply[F[_], G[_]](implicit lk: LiftKind[F, G]): LiftKind[F, G] = lk
+
+  implicit def id[F[_]: Applicative]: LiftKind[F, F] = new Identity[F]
+
+  /*
+   The compositional implicits are sufficient to derive all implicit instances,
+   but non-compositional ones with higher priority are provided to avoid
+   unnecessary allocation.
+   */
+
+  implicit def eitherT[F[_], L](implicit F: Monad[F]): LiftKind[F, EitherT[F, L, *]] =
+    eitherTImpl(F)
+
+  implicit def iorT[F[_], L: Semigroup](implicit F: Monad[F]): LiftKind[F, IorT[F, L, *]] =
+    iorTImpl(F)
+
+  implicit def kleisli[F[_], A](implicit F: Applicative[F]): LiftKind[F, Kleisli[F, A, *]] =
+    kleisliImpl(F)
+
+  implicit def optionT[F[_]](implicit F: Monad[F]): LiftKind[F, OptionT[F, *]] =
+    optionTImpl(F)
+
+  implicit def writerT[F[_], L: Monoid](
+      implicit F: Applicative[F]
+  ): LiftKind[F, WriterT[F, L, *]] =
+    writerTImpl(F)
+}
+
+private[mtl] sealed trait LowPriorityLiftKindInstances {
+  protected[this] def eitherTImpl[F[_], L](F: Monad[F]): LiftKind[F, EitherT[F, L, *]] =
+    new LiftKind[F, EitherT[F, L, *]] {
+      implicit val applicativeF: Monad[F] = F
+      val applicativeG: Applicative[EitherT[F, L, *]] = EitherT.catsDataMonadErrorForEitherT
+      def apply[A](fa: F[A]): EitherT[F, L, A] = EitherT.liftF(fa)
+      def limitedMapK[A](ga: EitherT[F, L, A])(scope: F ~> F): EitherT[F, L, A] =
+        ga.mapK(scope)
+    }
+
+  implicit def eitherTComposed[F[_], G[_], L](
+      implicit inner: LiftKind[F, G],
+      G: Monad[G]
+  ): LiftKind[F, EitherT[G, L, *]] =
+    inner.andThen(eitherTImpl(G))
+
+  protected[this] def iorTImpl[F[_], L: Semigroup](F: Monad[F]): LiftKind[F, IorT[F, L, *]] =
+    new LiftKind[F, IorT[F, L, *]] {
+      implicit val applicativeF: Monad[F] = F
+      val applicativeG: Applicative[IorT[F, L, *]] = IorT.catsDataMonadErrorForIorT
+      def apply[A](fa: F[A]): IorT[F, L, A] = IorT.liftF(fa)
+      def limitedMapK[A](ga: IorT[F, L, A])(scope: F ~> F): IorT[F, L, A] =
+        ga.mapK(scope)
+    }
+
+  implicit def iorTComposed[F[_], G[_], L: Semigroup](
+      implicit inner: LiftKind[F, G],
+      G: Monad[G]
+  ): LiftKind[F, IorT[G, L, *]] =
+    inner.andThen(iorTImpl(G))
+
+  protected[this] def kleisliImpl[F[_], A](F: Applicative[F]): LiftKind[F, Kleisli[F, A, *]] =
+    new LiftKind[F, Kleisli[F, A, *]] {
+      implicit val applicativeF: Applicative[F] = F
+      val applicativeG: Applicative[Kleisli[F, A, *]] = Kleisli.catsDataApplicativeForKleisli
+      def apply[B](fa: F[B]): Kleisli[F, A, B] = Kleisli.liftF(fa)
+      def limitedMapK[B](ga: ReaderT[F, A, B])(scope: F ~> F): ReaderT[F, A, B] =
+        ga.mapK(scope)
+    }
+
+  implicit def kleisliComposed[F[_], G[_], A](
+      implicit inner: LiftKind[F, G]
+  ): LiftKind[F, Kleisli[G, A, *]] =
+    inner.andThen(kleisliImpl(inner.applicativeG))
+
+  protected[this] def optionTImpl[F[_]](F: Monad[F]): LiftKind[F, OptionT[F, *]] =
+    new LiftKind[F, OptionT[F, *]] {
+      implicit val applicativeF: Monad[F] = F
+      val applicativeG: Applicative[OptionT[F, *]] = OptionT.catsDataMonadForOptionT
+      def apply[A](fa: F[A]): OptionT[F, A] = OptionT.liftF(fa)
+      def limitedMapK[A](ga: OptionT[F, A])(scope: F ~> F): OptionT[F, A] =
+        ga.mapK(scope)
+    }
+
+  implicit def optionTComposed[F[_], G[_]](
+      implicit inner: LiftKind[F, G],
+      G: Monad[G]
+  ): LiftKind[F, OptionT[G, *]] =
+    inner.andThen(optionTImpl(G))
+
+  protected[this] def writerTImpl[F[_], L: Monoid](
+      F: Applicative[F]
+  ): LiftKind[F, WriterT[F, L, *]] =
+    new LiftKind[F, WriterT[F, L, *]] {
+      implicit val applicativeF: Applicative[F] = F
+      val applicativeG: Applicative[WriterT[F, L, *]] = WriterT.catsDataApplicativeForWriterT
+      def apply[A](fa: F[A]): WriterT[F, L, A] = WriterT.liftF(fa)
+      def limitedMapK[A](ga: WriterT[F, L, A])(scope: F ~> F): WriterT[F, L, A] =
+        ga.mapK(scope)
+    }
+
+  implicit def writerTComposed[F[_], G[_], L: Monoid](
+      implicit inner: LiftKind[F, G]
+  ): LiftKind[F, WriterT[G, L, *]] =
+    inner.andThen(writerTImpl(inner.applicativeG))
+}

--- a/core/src/main/scala/cats/mtl/LiftValue.scala
+++ b/core/src/main/scala/cats/mtl/LiftValue.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+
+import cats.data.{ReaderWriterStateT => RWST, _}
+
+import scala.annotation.implicitNotFound
+import scala.{unchecked => uc}
+
+/** Lifts values from the higher-kinded type `F` to the higher-kinded type `G`. */
+@implicitNotFound("no way defined to lift values from ${F} to ${G}")
+trait LiftValue[F[_], G[_]] extends (F ~> G) {
+
+  /** An [[cats.Applicative `Applicative`]] instance for the higher-kinded type `F`. */
+  def applicativeF: Applicative[F]
+
+  /** An [[cats.Applicative `Applicative`]] instance for the higher-kinded type `G`. */
+  def applicativeG: Applicative[G]
+
+  /**
+   * Lifts `F[A]` to `G[A]`.
+   *
+   * @note
+   *   This method is usually best implemented by a `liftF` method on `G`'s companion object.
+   */
+  def apply[A](fa: F[A]): G[A]
+
+  /** @return an instance that lifts `E` to `F` and then `F` to `G` */
+  def compose[E[_]](that: LiftValue[E, F]): LiftValue[E, G] =
+    LiftValue.Composed(that, this)
+
+  /** @return an instance that lifts `F` to `G` and then `G` to `H` */
+  def andThen[H[_]](that: LiftValue[G, H]): LiftValue[F, H] =
+    LiftValue.Composed(this, that)
+}
+
+object LiftValue extends LowPriorityLiftValueInstances {
+
+  private[mtl] class Identity[F[_]](implicit val applicative: Applicative[F])
+      extends LiftValue[F, F] {
+    final def applicativeF: Applicative[F] = applicative
+    final def applicativeG: Applicative[F] = applicative
+    final def apply[A](fa: F[A]): F[A] = fa
+  }
+
+  private[this] final class Composed[F[_], G[_], H[_]] private (
+      inner: LiftValue[F, G],
+      outer: LiftValue[G, H]
+  ) extends LiftValue[F, H] {
+    def applicativeF: Applicative[F] = inner.applicativeF
+    def applicativeG: Applicative[H] = outer.applicativeG
+    def apply[A](fa: F[A]): H[A] = outer(inner(fa))
+  }
+
+  private object Composed {
+    def apply[F[_], G[_], H[_]](
+        inner: LiftValue[F, G],
+        outer: LiftValue[G, H]
+    ): LiftValue[F, H] =
+      if (inner.isInstanceOf[Identity[F @uc]]) outer.asInstanceOf[LiftValue[F, H]]
+      else if (outer.isInstanceOf[Identity[G @uc]]) inner.asInstanceOf[LiftValue[F, H]]
+      else new Composed(inner, outer)
+  }
+
+  def apply[F[_], G[_]](implicit lv: LiftValue[F, G]): LiftValue[F, G] = lv
+
+  implicit def id[F[_]: Applicative]: LiftValue[F, F] = new Identity[F]
+
+  /*
+   The compositional implicits are sufficient to derive all implicit instances,
+   but non-compositional ones with higher priority are provided to avoid
+   unnecessary allocation.
+   */
+
+  implicit def eitherT[F[_], L](implicit F: Monad[F]): LiftValue[F, EitherT[F, L, *]] =
+    eitherTImpl(F)
+
+  implicit def iorT[F[_], L: Semigroup](implicit F: Monad[F]): LiftValue[F, IorT[F, L, *]] =
+    iorTImpl(F)
+
+  implicit def kleisli[F[_], A](implicit F: Applicative[F]): LiftValue[F, Kleisli[F, A, *]] =
+    kleisliImpl(F)
+
+  implicit def optionT[F[_]](implicit F: Monad[F]): LiftValue[F, OptionT[F, *]] =
+    optionTImpl(F)
+
+  implicit def rwst[F[_], E, L: Monoid, S](
+      implicit F: Monad[F]
+  ): LiftValue[F, RWST[F, E, L, S, *]] =
+    rwstImpl(F)
+
+  implicit def stateT[F[_], S](implicit F: Monad[F]): LiftValue[F, StateT[F, S, *]] =
+    stateTImpl(F)
+
+  implicit def writerT[F[_], L: Monoid](
+      implicit F: Applicative[F]
+  ): LiftValue[F, WriterT[F, L, *]] =
+    writerTImpl(F)
+}
+
+private[mtl] sealed trait LowPriorityLiftValueInstances {
+  protected[this] def eitherTImpl[F[_], L](F: Monad[F]): LiftValue[F, EitherT[F, L, *]] =
+    new LiftValue[F, EitherT[F, L, *]] {
+      implicit val applicativeF: Monad[F] = F
+      val applicativeG: Applicative[EitherT[F, L, *]] = EitherT.catsDataMonadErrorForEitherT
+      def apply[A](fa: F[A]): EitherT[F, L, A] = EitherT.liftF(fa)
+    }
+
+  implicit def eitherTComposed[F[_], G[_], L](
+      implicit inner: LiftValue[F, G],
+      G: Monad[G]
+  ): LiftValue[F, EitherT[G, L, *]] =
+    inner.andThen(eitherTImpl(G))
+
+  protected[this] def iorTImpl[F[_], L: Semigroup](F: Monad[F]): LiftValue[F, IorT[F, L, *]] =
+    new LiftValue[F, IorT[F, L, *]] {
+      implicit val applicativeF: Monad[F] = F
+      val applicativeG: Applicative[IorT[F, L, *]] = IorT.catsDataMonadErrorForIorT
+      def apply[A](fa: F[A]): IorT[F, L, A] = IorT.liftF(fa)
+    }
+
+  implicit def iorTComposed[F[_], G[_], L: Semigroup](
+      implicit inner: LiftValue[F, G],
+      G: Monad[G]
+  ): LiftValue[F, IorT[G, L, *]] =
+    inner.andThen(iorTImpl(G))
+
+  protected[this] def kleisliImpl[F[_], A](F: Applicative[F]): LiftValue[F, Kleisli[F, A, *]] =
+    new LiftValue[F, Kleisli[F, A, *]] {
+      implicit val applicativeF: Applicative[F] = F
+      val applicativeG: Applicative[Kleisli[F, A, *]] = Kleisli.catsDataApplicativeForKleisli
+      def apply[B](fa: F[B]): Kleisli[F, A, B] = Kleisli.liftF(fa)
+    }
+
+  implicit def kleisliComposed[F[_], G[_], A](
+      implicit inner: LiftValue[F, G]
+  ): LiftValue[F, Kleisli[G, A, *]] =
+    inner.andThen(kleisliImpl(inner.applicativeG))
+
+  protected[this] def optionTImpl[F[_]](F: Monad[F]): LiftValue[F, OptionT[F, *]] =
+    new LiftValue[F, OptionT[F, *]] {
+      implicit val applicativeF: Monad[F] = F
+      val applicativeG: Applicative[OptionT[F, *]] = OptionT.catsDataMonadForOptionT
+      def apply[A](fa: F[A]): OptionT[F, A] = OptionT.liftF(fa)
+    }
+
+  implicit def optionTComposed[F[_], G[_]](
+      implicit inner: LiftValue[F, G],
+      G: Monad[G]
+  ): LiftValue[F, OptionT[G, *]] =
+    inner.andThen(optionTImpl(G))
+
+  protected[this] def rwstImpl[F[_], E, L: Monoid, S](
+      F: Monad[F]
+  ): LiftValue[F, RWST[F, E, L, S, *]] =
+    new LiftValue[F, RWST[F, E, L, S, *]] {
+      implicit val applicativeF: Monad[F] = F
+      val applicativeG: Applicative[RWST[F, E, L, S, *]] =
+        IndexedReaderWriterStateT.catsDataMonadForRWST
+      def apply[A](fa: F[A]): RWST[F, E, L, S, A] = RWST.liftF(fa)
+    }
+
+  implicit def rwstComposed[F[_], G[_], E, L: Monoid, S](
+      implicit inner: LiftValue[F, G],
+      G: Monad[G]
+  ): LiftValue[F, RWST[G, E, L, S, *]] =
+    inner.andThen(rwstImpl(G))
+
+  protected[this] def stateTImpl[F[_], S](F: Monad[F]): LiftValue[F, StateT[F, S, *]] =
+    new LiftValue[F, StateT[F, S, *]] {
+      implicit val applicativeF: Monad[F] = F
+      val applicativeG: Applicative[StateT[F, S, *]] =
+        IndexedStateT.catsDataMonadForIndexedStateT
+      def apply[A](fa: F[A]): StateT[F, S, A] = StateT.liftF(fa)
+    }
+
+  implicit def stateTComposed[F[_], G[_], S](
+      implicit inner: LiftValue[F, G],
+      G: Monad[G]
+  ): LiftValue[F, StateT[G, S, *]] =
+    inner.andThen(stateTImpl(G))
+
+  protected[this] def writerTImpl[F[_], L: Monoid](
+      F: Applicative[F]
+  ): LiftValue[F, WriterT[F, L, *]] =
+    new LiftValue[F, WriterT[F, L, *]] {
+      implicit val applicativeF: Applicative[F] = F
+      val applicativeG: Applicative[WriterT[F, L, *]] = WriterT.catsDataApplicativeForWriterT
+      def apply[A](fa: F[A]): WriterT[F, L, A] = WriterT.liftF(fa)
+    }
+
+  implicit def writerTComposed[F[_], G[_], L: Monoid](
+      implicit inner: LiftValue[F, G]
+  ): LiftValue[F, WriterT[G, L, *]] =
+    inner.andThen(writerTImpl(inner.applicativeG))
+}

--- a/core/src/main/scala/cats/mtl/MonadPartialOrder.scala
+++ b/core/src/main/scala/cats/mtl/MonadPartialOrder.scala
@@ -26,9 +26,12 @@ import cats.data._
  *
  * Original idea by Kris Nuttycombe.
  */
-trait MonadPartialOrder[F[_], G[_]] extends (F ~> G) {
+trait MonadPartialOrder[F[_], G[_]] extends LiftValue[F, G] {
   def monadF: Monad[F]
   def monadG: Monad[G]
+
+  final def applicativeF: Applicative[F] = monadF
+  final def applicativeG: Applicative[G] = monadG
 }
 
 private[mtl] trait MonadPartialOrderInstances {

--- a/laws/src/main/scala/cats/mtl/laws/LiftKindLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/LiftKindLaws.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+package laws
+
+import cats.arrow.FunctionK
+import cats.laws.IsEq
+import cats.laws.IsEqArrow
+
+trait LiftKindLaws[F[_], G[_]] extends LiftValueLaws[F, G] {
+  implicit def lift: LiftKind[F, G]
+
+  // external law:
+  def limitedMapKIdentityIsPure[A](value: G[A]): IsEq[G[A]] =
+    lift.limitedMapK(value)(FunctionK.id) <-> value
+
+  // internal laws:
+  def liftScopeIsLimitedMapKLiftScope[A](value: F[A], scope: F ~> F): IsEq[G[A]] =
+    lift(scope(value)) <-> lift.limitedMapK(lift(value))(scope)
+
+  def limitedMapKLiftScopeConsistency[A](value: G[A], scope: F ~> F): IsEq[G[A]] =
+    lift.limitedMapK(value)(scope) <-> lift.liftScope(scope)(value)
+}
+
+object LiftKindLaws {
+  def apply[F[_], G[_]](implicit liftKind: LiftKind[F, G]): LiftKindLaws[F, G] =
+    new LiftKindLaws[F, G] {
+      implicit val lift: LiftKind[F, G] = liftKind
+    }
+}

--- a/laws/src/main/scala/cats/mtl/laws/LiftValueLaws.scala
+++ b/laws/src/main/scala/cats/mtl/laws/LiftValueLaws.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+package laws
+
+import cats.laws.IsEq
+import cats.laws.IsEqArrow
+
+trait LiftValueLaws[F[_], G[_]] {
+  implicit def lift: LiftValue[F, G]
+  implicit final def F: Applicative[F] = lift.applicativeF
+  implicit final def G: Applicative[G] = lift.applicativeG
+
+  // external laws:
+  def liftPureIsPure[A](value: A): IsEq[G[A]] =
+    lift(F.pure(value)) <-> G.pure(value)
+
+  def liftApIsApLift[A, B](fa: F[A], ff: F[A => B]): IsEq[G[B]] =
+    lift(F.ap(ff)(fa)) <-> G.ap(lift(ff))(lift(fa))
+}
+
+object LiftValueLaws {
+  def apply[F[_], G[_]](implicit liftValue: LiftValue[F, G]): LiftValueLaws[F, G] =
+    new LiftValueLaws[F, G] {
+      implicit val lift: LiftValue[F, G] = liftValue
+    }
+}

--- a/laws/src/main/scala/cats/mtl/laws/discipline/LiftKindTests.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/LiftKindTests.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+package laws
+package discipline
+
+import cats.kernel.laws.discipline.catsLawsIsEqToProp
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.{forAll => ∀}
+
+trait LiftKindTests[F[_], G[_]] extends LiftValueTests[F, G] {
+  implicit val liftInstance: LiftKind[F, G]
+
+  override def laws: LiftKindLaws[F, G] = LiftKindLaws[F, G]
+
+  def liftKind[A, B](
+      implicit arbA: Arbitrary[A],
+      arbFA: Arbitrary[F[A]],
+      arbFAB: Arbitrary[F[A => B]],
+      arbGA: Arbitrary[G[A]],
+      arbFF: Arbitrary[F ~> F],
+      eqGA: Eq[G[A]],
+      eqGB: Eq[G[B]]
+  ): RuleSet =
+    new DefaultRuleSet(
+      name = "liftKind",
+      parent = Some(liftValue[A, B]),
+      "limitedMapK(identity) is pure" -> ∀(laws.limitedMapKIdentityIsPure[A] _),
+      "lift(scope) is limitedMapK(lift)(scope)" -> ∀(laws.liftScopeIsLimitedMapKLiftScope[A] _),
+      "limitedMapK and liftScope are consistent" -> ∀(laws.limitedMapKLiftScopeConsistency[A] _)
+    )
+}
+
+object LiftKindTests {
+  def apply[F[_], G[_]](implicit lift: LiftKind[F, G]): LiftKindTests[F, G] =
+    new LiftKindTests[F, G] {
+      implicit val liftInstance: LiftKind[F, G] = lift
+    }
+
+  implicit val arbitraryFunctionKListList: Arbitrary[List ~> List] =
+    Arbitrary(ListGens.genFunctionKListList)
+}

--- a/laws/src/main/scala/cats/mtl/laws/discipline/LiftValueTests.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/LiftValueTests.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+package laws
+package discipline
+
+import cats.kernel.laws.discipline.catsLawsIsEqToProp
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.{forAll => ∀}
+import org.typelevel.discipline.Laws
+
+trait LiftValueTests[F[_], G[_]] extends Laws {
+  implicit val liftInstance: LiftValue[F, G]
+  implicit final def F: Applicative[F] = liftInstance.applicativeF
+  implicit final def G: Applicative[G] = liftInstance.applicativeG
+
+  def laws: LiftValueLaws[F, G] = LiftValueLaws[F, G]
+
+  def liftValue[A, B](
+      implicit arbA: Arbitrary[A],
+      arbFA: Arbitrary[F[A]],
+      arbFAB: Arbitrary[F[A => B]],
+      eqGA: Eq[G[A]],
+      eqGB: Eq[G[B]]
+  ): RuleSet =
+    new SimpleRuleSet(
+      name = "liftValue",
+      "lift(pure) is pure" -> ∀(laws.liftPureIsPure[A] _),
+      "lift(ap) is ap(lift, lift)" -> ∀(laws.liftApIsApLift[A, B] _)
+    )
+}
+
+object LiftValueTests {
+  def apply[F[_], G[_]](implicit lift: LiftValue[F, G]): LiftValueTests[F, G] =
+    new LiftValueTests[F, G] {
+      implicit val liftInstance: LiftValue[F, G] = lift
+    }
+}

--- a/laws/src/main/scala/cats/mtl/laws/discipline/ListGens.scala
+++ b/laws/src/main/scala/cats/mtl/laws/discipline/ListGens.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl.laws.discipline
+
+import org.scalacheck.Gen
+
+private[discipline] object ListGens {
+  private[this] val smallPositiveInt: Gen[Int] = Gen.oneOf(1 to 5)
+
+  private[this] def genListDrop: Gen[List ~> List] =
+    for (count <- smallPositiveInt)
+      yield new (List ~> List) {
+        def apply[A](list: List[A]): List[A] = list.drop(count)
+        override def toString: String = s"List#drop($count)"
+      }
+
+  private[this] def genListTake: Gen[List ~> List] =
+    for (count <- smallPositiveInt)
+      yield new (List ~> List) {
+        def apply[A](list: List[A]): List[A] = list.take(count)
+        override def toString: String = s"List#take($count)"
+      }
+
+  private[this] def genListSlice: Gen[List ~> List] =
+    for {
+      start <- smallPositiveInt
+      offset <- smallPositiveInt
+    } yield new (List ~> List) {
+      def apply[A](list: List[A]): List[A] =
+        list.slice(start, start + offset)
+      override def toString: String = s"List#slice($start, $offset)"
+    }
+
+  private[this] def genListFilterEvenOrOddIndices: Gen[List ~> List] =
+    for (remainder <- Gen.oneOf(0, 1))
+      yield new (List ~> List) {
+        def apply[A](list: List[A]): List[A] =
+          list.view.zipWithIndex.filter(_._2 % 2 == remainder).map(_._1).toList
+        override def toString: String =
+          s"List#filter(<index is ${if (remainder == 0) "even" else "odd"}>)"
+      }
+
+  val genFunctionKListList: Gen[List ~> List] =
+    Gen.oneOf(
+      genListDrop,
+      genListTake,
+      genListSlice,
+      genListFilterEvenOrOddIndices
+    )
+}

--- a/tests/shared/src/test/scala/cats/mtl/tests/BaseSuite.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/BaseSuite.scala
@@ -31,6 +31,20 @@ abstract class BaseSuite extends FunSuite with EqSyntax with DisciplineSuite {
   implicit def catsMtlLawsExhaustiveCheckForArbitrary[A: Arbitrary]: ExhaustiveCheck[A] =
     ExhaustiveCheck.instance(Gen.resize(30, Arbitrary.arbitrary[List[A]]).sample.get)
 
+  protected type EitherTStr[M[_], A] = EitherT[M, String, A]
+  protected type EitherTStrId[A] = EitherT[Id, String, A]
+  protected type EitherTInt[M[_], A] = EitherT[M, Int, A]
+  protected type EitherTIntId[A] = EitherT[Id, Int, A]
+  protected type EitherTStrEitherTInt[A] = EitherTStr[EitherTIntId, A]
+
+  protected type IorTStrId[A] = IorT[Id, String, A]
+  protected type IorTIntId[A] = IorT[Id, Int, A]
+
+  protected type KleisliStrId[A] = Kleisli[Id, String, A]
+  protected type KleisliIntId[A] = Kleisli[Id, Int, A]
+
+  protected type OptionTId[A] = OptionT[Id, A]
+
   protected type ReaderStr[M[_], A] = ReaderT[M, String, A]
   protected type ReaderStrId[A] = ReaderT[Id, String, A]
   protected type ReaderInt[M[_], A] = ReaderT[M, Int, A]
@@ -38,24 +52,19 @@ abstract class BaseSuite extends FunSuite with EqSyntax with DisciplineSuite {
   protected type ReaderStrInt[A] = ReaderStr[ReaderIntId, A]
   protected type ReaderStrFuncInt[A] = ReaderStr[FunctionC[Int]#l, A]
 
-  protected type EitherTStr[M[_], A] = EitherT[M, String, A]
-  protected type EitherStrId[A] = EitherT[Id, String, A]
-  protected type EitherTInt[M[_], A] = EitherT[M, Int, A]
-  protected type EitherTIntId[A] = EitherT[Id, Int, A]
-  protected type EitherTStrEitherTInt[A] = EitherTStr[EitherTIntId, A]
-
   protected type StateTStr[M[_], A] = StateT[M, String, A]
-  protected type StateStrId[A] = StateT[Id, String, A]
+  protected type StateTStrId[A] = StateT[Id, String, A]
   protected type StateTInt[M[_], A] = StateT[M, Int, A]
   protected type StateTIntId[A] = StateT[Id, Int, A]
   protected type StateTStrStateTInt[A] = StateTStr[StateTIntId, A]
 
   protected type WriterTStr[M[_], A] = WriterT[M, String, A]
-  protected type WriterStrId[A] = WriterT[Id, String, A]
+  protected type WriterTStrId[A] = WriterT[Id, String, A]
   protected type WriterTInt[M[_], A] = WriterT[M, Vector[Int], A]
   protected type WriterTIntId[A] = WriterT[Id, Vector[Int], A]
   protected type WriterTStrWriterTInt[A] = WriterTStr[WriterTIntId, A]
   protected type WriterTStrTupleInt[A] = WriterTStr[TupleC[Vector[Int]]#l, A]
+
   protected type ReaderTStringOverWriterTStringOverOption[A] =
     ReaderT[WriterTC[Option, String]#l, List[Int], A]
   protected type StateTStringOverWriterTStringOverOption[A] =

--- a/tests/shared/src/test/scala/cats/mtl/tests/LiftKindLawTests.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/LiftKindLawTests.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+package tests
+
+import cats.data._
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import cats.mtl.laws.discipline.LiftKindTests
+import org.scalacheck.Arbitrary
+
+class LiftKindLawTests extends BaseSuite {
+  import LiftKindTests.arbitraryFunctionKListList
+
+  implicit def eqKleisli[F[_], A, B](
+      implicit arbA: Arbitrary[A],
+      eqFB: Eq[F[B]]
+  ): Eq[Kleisli[F, A, B]] =
+    Eq.by(_.run)
+
+  // identity
+  checkAll("LiftKind[List, List]", LiftKindTests[List, List].liftKind[String, Int])
+
+  // non-compositional
+  checkAll(
+    "LiftKind[List, EitherT[List, Int, *]]",
+    LiftKindTests[List, EitherT[List, Int, *]].liftKind[String, Int]
+  )
+  checkAll(
+    "LiftKind[List, IorT[List, Int, *]]",
+    LiftKindTests[List, IorT[List, Int, *]].liftKind[String, Int]
+  )
+  checkAll(
+    "LiftKind[List, Kleisli[List, Int, *]]",
+    LiftKindTests[List, Kleisli[List, Int, *]].liftKind[String, Int]
+  )
+  checkAll(
+    "LiftKind[List, OptionT[List, *]]",
+    LiftKindTests[List, OptionT[List, *]].liftKind[String, Int]
+  )
+  checkAll(
+    "LiftKind[List, WriterT[List, Int, *]]",
+    LiftKindTests[List, WriterT[List, Int, *]].liftKind[String, Int]
+  )
+
+  // compositional
+  checkAll(
+    "LiftKind[List, EitherT[OptionT[List, *], Int, *]]",
+    LiftKindTests[List, EitherT[OptionT[List, *], Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftKind[List, IorT[OptionT[List, *], Int, *]]",
+    LiftKindTests[List, IorT[OptionT[List, *], Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftKind[List, Kleisli[OptionT[List, *], Int, *]]",
+    LiftKindTests[List, Kleisli[OptionT[List, *], Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftKind[List, OptionT[IorT[List, Int, *], *]]",
+    LiftKindTests[List, OptionT[IorT[List, Int, *], *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftKind[List, WriterT[OptionT[List, *], Int, *]]",
+    LiftKindTests[List, WriterT[OptionT[List, *], Int, *]].liftValue[String, Int]
+  )
+}

--- a/tests/shared/src/test/scala/cats/mtl/tests/LiftValueLawTests.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/LiftValueLawTests.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cats
+package mtl
+package tests
+
+import cats.data.{ReaderWriterStateT => RWST, _}
+import cats.laws.discipline.eq._
+import cats.mtl.laws.discipline.LiftValueTests
+import org.scalacheck.Arbitrary
+
+class LiftValueLawTests extends BaseSuite {
+  implicit def eqKleisli[F[_], A, B](
+      implicit arbA: Arbitrary[A],
+      eqFB: Eq[F[B]]
+  ): Eq[Kleisli[F, A, B]] =
+    Eq.by(_.run)
+
+  implicit def stateTEq[F[_]: FlatMap, S, A](
+      implicit arbS: Arbitrary[S],
+      eqFSA: Eq[F[(S, A)]]
+  ): Eq[StateT[F, S, A]] =
+    Eq.by(state => (s: S) => state.run(s))
+
+  implicit def rwstEq[F[_]: Monad, E, L, S, A](
+      implicit arbE: Arbitrary[E],
+      arbS: Arbitrary[S],
+      eqFLSA: Eq[F[(L, S, A)]]
+  ): Eq[RWST[F, E, L, S, A]] =
+    Eq.by(rwst => (e: E, s: S) => rwst.run(e, s))
+
+  // identity
+  checkAll("LiftValue[List, List]", LiftValueTests[List, List].liftValue[String, Int])
+
+  // non-compositional
+  checkAll(
+    "LiftValue[List, EitherT[List, Int, *]]",
+    LiftValueTests[List, EitherT[List, Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, IorT[List, Int, *]]",
+    LiftValueTests[List, IorT[List, Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, Kleisli[List, Int, *]]",
+    LiftValueTests[List, Kleisli[List, Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, OptionT[List, *]]",
+    LiftValueTests[List, OptionT[List, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, RWST[List, Int, Int, Int, *]]",
+    LiftValueTests[List, RWST[List, Int, Int, Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, StateT[List, Int, *]]",
+    LiftValueTests[List, StateT[List, Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, WriterT[List, Int, *]]",
+    LiftValueTests[List, WriterT[List, Int, *]].liftValue[String, Int]
+  )
+
+  // compositional
+  checkAll(
+    "LiftValue[List, EitherT[OptionT[List, *], Int, *]]",
+    LiftValueTests[List, EitherT[OptionT[List, *], Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, IorT[OptionT[List, *], Int, *]]",
+    LiftValueTests[List, IorT[OptionT[List, *], Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, Kleisli[OptionT[List, *], Int, *]]",
+    LiftValueTests[List, Kleisli[OptionT[List, *], Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, OptionT[IorT[List, Int, *], *]]",
+    LiftValueTests[List, OptionT[IorT[List, Int, *], *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, RWST[OptionT[List, *], Int, Int, Int, *]]",
+    LiftValueTests[List, RWST[OptionT[List, *], Int, Int, Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, StateT[OptionT[List, *], Int, *]]",
+    LiftValueTests[List, StateT[OptionT[List, *], Int, *]].liftValue[String, Int]
+  )
+  checkAll(
+    "LiftValue[List, WriterT[OptionT[List, *], Int, *]]",
+    LiftValueTests[List, WriterT[OptionT[List, *], Int, *]].liftValue[String, Int]
+  )
+}

--- a/tests/shared/src/test/scala/cats/mtl/tests/SummonableImplicits.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/SummonableImplicits.scala
@@ -18,6 +18,8 @@ package cats
 package mtl
 package tests
 
+import cats.data.{ReaderWriterStateT => RWST, _}
+
 final class SummonableImplicits extends BaseSuite {
 
   locally {
@@ -28,15 +30,41 @@ final class SummonableImplicits extends BaseSuite {
     }
 
     {
-      Listen[WriterStrId, String]
-      Listen[WriterTStrWriterTInt, String]
-      Listen[WriterTStrWriterTInt, Vector[Int]]
+      LiftValue[Id, Id]
+      LiftValue[Id, OptionTId]
+      LiftValue[Id, EitherTStrId]
+      LiftValue[Id, EitherTIntId]
+      LiftValue[Id, IorTStrId]
+      LiftValue[Id, IorTIntId]
+      LiftValue[Id, KleisliStrId]
+      LiftValue[Id, KleisliIntId]
+      LiftValue[Id, WriterTStrId]
+      LiftValue[Id, WriterTIntId]
+      LiftValue[Id, StateTStrId]
+      LiftValue[Id, StateTIntId]
+      LiftValue[Id, RWST[Id, Int, Int, Int, *]]
+      LiftValue[Id, RWST[Id, String, String, String, *]]
+      LiftValue[Id, OptionT[IorT[Id, Int, *], *]]
     }
 
     {
-      Raise[EitherStrId, String]
-      // Raise[EitherTStrEitherTInt, Int]
-      Raise[EitherTStrEitherTInt, String]
+      LiftKind[Id, Id]
+      LiftKind[Id, OptionTId]
+      LiftKind[Id, EitherTStrId]
+      LiftKind[Id, EitherTIntId]
+      LiftKind[Id, IorTStrId]
+      LiftKind[Id, IorTIntId]
+      LiftKind[Id, KleisliStrId]
+      LiftKind[Id, KleisliIntId]
+      LiftKind[Id, WriterTStrId]
+      LiftKind[Id, WriterTIntId]
+      LiftKind[Id, OptionT[IorT[Id, Int, *], *]]
+    }
+
+    {
+      Listen[WriterTStrId, String]
+      Listen[WriterTStrWriterTInt, String]
+      Listen[WriterTStrWriterTInt, Vector[Int]]
     }
 
     {
@@ -46,13 +74,19 @@ final class SummonableImplicits extends BaseSuite {
     }
 
     {
-      Stateful[StateStrId, String]
+      Raise[EitherTStrId, String]
+      // Raise[EitherTStrEitherTInt, Int]
+      Raise[EitherTStrEitherTInt, String]
+    }
+
+    {
+      Stateful[StateTStrId, String]
       Stateful[StateTStrStateTInt, String]
       Stateful[StateTStrStateTInt, Int]
     }
 
     {
-      Tell[WriterStrId, String]
+      Tell[WriterTStrId, String]
       Tell[WriterTStrWriterTInt, String]
       Tell[WriterTStrWriterTInt, Vector[Int]]
     }


### PR DESCRIPTION
Add `LiftValue` and `LiftKind`.

Make `MonadPartialOrder` a subtype of `LiftValue`.

The motivation for this PR is the desire to add a `LocalLogger` to log4cats that can store log context in a `cats.mtl.Local`. log4cats loggers have a `mapK` method; supporting `mapK` on a `LocalLogger` requires being able to transform a `Local[F, *]` into a `Local[G, *]`, which in turn requires the functionality exposed by ~~`KindTransformer`~~ **`LiftKind`**.

`LiftKind` (formerly `KindTransformer`) is originally (and currently) from otel4s, designed by me (so we don't need to worry about attributing it to otel4s as I am simply personally (re)licensing my own code/design to typelevel/cats-mtl here).