### PR TITLE
Fix source compatibility with Scala 3.6

### DIFF
--- a/tests/shared/src/test/scala/cats/mtl/tests/AskCatsInstanceTests.scala
+++ b/tests/shared/src/test/scala/cats/mtl/tests/AskCatsInstanceTests.scala
@@ -34,7 +34,7 @@ class AskCatsInstanceTests extends BaseSuite {
   checkAll(
     "Applicative[Ask[Option, *]]",
     ApplicativeTests[Ask[Option, *]](
-      Ask.applicativeAsk[Option] // make sure we test the weaker applicative instance
+      using Ask.applicativeAsk[Option] // make sure we test the weaker applicative instance
     ).applicative[String, String, String]
   )
 


### PR DESCRIPTION
This PR adds a `using` before implicit arguments, allowing the project to compile under Scala 3.6. See https://github.com/typelevel/cats/pull/4737 for more details.