### PR TITLE
Mention Handle.allowF in Raise's implicitNotFound message

### DIFF
--- a/core/src/main/scala/cats/mtl/Raise.scala
+++ b/core/src/main/scala/cats/mtl/Raise.scala
@@ -62,7 +62,7 @@ import scala.util.control.NonFatal
  * }}}
  */
 @implicitNotFound(
-  "Could not find an implicit instance of Raise[${F}, ${E}]. If you have\na good way of handling errors of type ${E} at this location, you may want\nto construct a value of type EitherT for this call-site, rather than ${F}.\nAn example type:\n\n  EitherT[${F}, ${E}, *]\n\nThis is analogous to writing try/catch around this call. The EitherT will\n\"catch\" the errors of type ${E}.\n\nIf you do not wish to handle errors of type ${E} at this location, you should\nadd an implicit parameter of this type to your function. For example:\n\n  (implicit fraise: Raise[${F}, ${E}])\n")
+  "Could not find an implicit instance of Raise[${F}, ${E}]. If you have a\ngood way of handling errors of type ${E} at this location, you may want\nto wrap the call-site in Handle.allowF, like so:\n\n  Handle.allowF[${F}, ${E}] { implicit h =>\n    // call code requiring Raise[${F}, ${E}]\n  }.rescue { e: ${E} =>\n    // handle the error\n  }\n\nThis is analogous to writing try/catch around this call ensuring that\nall errors of type ${E} are handled in the rescue block.\n\nAlternatively, you may want to construct a value of type EitherT for\nthis call-site, rather than ${F}.\nAn example type:\n\n  EitherT[${F}, ${E}, *]\n\nThe EitherT will \"catch\" the errors of type ${E}.\n\nIf you do not wish to handle errors of type ${E} at this location, you should\nadd an implicit parameter of this type to your function. For example:\n\n  (implicit fraise: Raise[${F}, ${E}])\n")
 trait Raise[F[_], -E] extends Serializable {
   def functor: Functor[F]
 


### PR DESCRIPTION
Example output:
```
scala> mayRaise[F]
               ^
       error: Could not find an implicit instance of Raise[F, Error]. If you have a
       good way of handling errors of type Error at this location, you may want
       to wrap the call-site in Handle.allowF, like so:

         Handle.allowF[F, Error] { implicit h =>
           // call code requiring Raise[F, Error]
         }.rescue { e: Error =>
           // handle the error
         }

       This is analogous to writing try/catch around this call ensuring that
       all errors of type Error are handled in the rescue block.

       Alternatively, you may want to construct a value of type EitherT for
       this call-site, rather than F.
       An example type:

         EitherT[F, Error, *]

       The EitherT will "catch" the errors of type Error.

       If you do not wish to handle errors of type Error at this location, you should
       add an implicit parameter of this type to your function. For example:

         (implicit fraise: Raise[F, Error])
``` 

Not sure what to do with Scala 3, is there an easier way to have a specific message to Scala 3 than splitting the trait into different files? Is it worth it?