### PR TITLE
Rename syntax implicits so they don't clash with other libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // import laika.helium.config._
 import laika.config.{ChoiceConfig, SelectionConfig, Selections}
-ThisBuild / tlBaseVersion := "1.6"
+ThisBuild / tlBaseVersion := "1.7"
 ThisBuild / startYear := Some(2021)
 ThisBuild / developers := List(
   tlGitHubDev("SystemFw", "Fabio Labella"),

--- a/core/src/main/scala/cats/mtl/syntax/ask.scala
+++ b/core/src/main/scala/cats/mtl/syntax/ask.scala
@@ -21,8 +21,8 @@ package syntax
 trait AskSyntax {
   implicit def catsMtlSyntaxToReaderOps[E, A](fun: E => A): ReaderOps[E, A] = new ReaderOps(fun)
 
-  @deprecated("use catsMtlSyntaxToReaderOps", "1.6.1") def toReaderOps[E, A](
-      fun: E => A): ReaderOps[E, A] = catsMtlSyntaxToReaderOps(fun)
+  @deprecated("use catsMtlSyntaxToReaderOps", "1.7.0")
+  def toReaderOps[E, A](fun: E => A): ReaderOps[E, A] = catsMtlSyntaxToReaderOps(fun)
 }
 
 final class ReaderOps[E, A](val fun: E => A) extends AnyVal {

--- a/core/src/main/scala/cats/mtl/syntax/chronicle.scala
+++ b/core/src/main/scala/cats/mtl/syntax/chronicle.scala
@@ -28,12 +28,14 @@ trait ChronicleSyntax {
   implicit def catsMtlSyntaxToChronicleIorOps[A, E](ior: E Ior A): ChronicleIorOps[A, E] =
     new ChronicleIorOps[A, E](ior)
 
-  @deprecated("use catsMtlSyntaxToChronicleOps", "1.6.1") def toChronicleOps[F[_], A](
-      fa: F[A]): ChronicleOps[F, A] = catsMtlSyntaxToChronicleOps[F, A](fa)
-  @deprecated("use catsMtlSyntaxToChronicleIdOps", "1.6.1") def toChronicleIdOps[E](
-      e: E): ChronicleIdOps[E] = catsMtlSyntaxToChronicleIdOps[E](e)
-  @deprecated("use catsMtlSyntaxToChronicleIorOps", "1.6.1") def toChronicleIorOps[A, E](
-      ior: E Ior A): ChronicleIorOps[A, E] = catsMtlSyntaxToChronicleIorOps[A, E](ior)
+  @deprecated("use catsMtlSyntaxToChronicleOps", "1.7.0")
+  def toChronicleOps[F[_], A](fa: F[A]): ChronicleOps[F, A] =
+    catsMtlSyntaxToChronicleOps[F, A](fa)
+  @deprecated("use catsMtlSyntaxToChronicleIdOps", "1.7.0")
+  def toChronicleIdOps[E](e: E): ChronicleIdOps[E] = catsMtlSyntaxToChronicleIdOps[E](e)
+  @deprecated("use catsMtlSyntaxToChronicleIorOps", "1.7.0")
+  def toChronicleIorOps[A, E](ior: E Ior A): ChronicleIorOps[A, E] =
+    catsMtlSyntaxToChronicleIorOps[A, E](ior)
 }
 
 final class ChronicleOps[F[_], A](val fa: F[A]) extends AnyVal {

--- a/core/src/main/scala/cats/mtl/syntax/handle.scala
+++ b/core/src/main/scala/cats/mtl/syntax/handle.scala
@@ -23,8 +23,8 @@ import cats.data.EitherT
 trait HandleSyntax {
   implicit def catsMtlSyntaxToHandleOps[F[_], A](fa: F[A]): HandleOps[F, A] = new HandleOps(fa)
 
-  @deprecated("use catsMtlSyntaxToHandleOps", "1.6.1") def toHandleOps[F[_], A](
-      fa: F[A]): HandleOps[F, A] = catsMtlSyntaxToHandleOps(fa)
+  @deprecated("use catsMtlSyntaxToHandleOps", "1.7.0")
+  def toHandleOps[F[_], A](fa: F[A]): HandleOps[F, A] = catsMtlSyntaxToHandleOps(fa)
 }
 
 final class HandleOps[F[_], A](val fa: F[A]) extends AnyVal {

--- a/core/src/main/scala/cats/mtl/syntax/listen.scala
+++ b/core/src/main/scala/cats/mtl/syntax/listen.scala
@@ -21,8 +21,8 @@ package syntax
 trait ListenSyntax {
   implicit def catsMtlSyntaxToListenOps[F[_], A](fa: F[A]): ListenOps[F, A] = new ListenOps(fa)
 
-  @deprecated("use catsMtlSyntaxToListenOps", "1.6.1") def toListenOps[F[_], A](
-      fa: F[A]): ListenOps[F, A] = catsMtlSyntaxToListenOps(fa)
+  @deprecated("use catsMtlSyntaxToListenOps", "1.7.0")
+  def toListenOps[F[_], A](fa: F[A]): ListenOps[F, A] = catsMtlSyntaxToListenOps(fa)
 }
 
 final class ListenOps[F[_], A](val fa: F[A]) extends AnyVal {

--- a/core/src/main/scala/cats/mtl/syntax/local.scala
+++ b/core/src/main/scala/cats/mtl/syntax/local.scala
@@ -21,8 +21,8 @@ package syntax
 trait LocalSyntax {
   implicit def catsMtlSyntaxToLocalOps[F[_], A](fa: F[A]): LocalOps[F, A] = new LocalOps(fa)
 
-  @deprecated("use catsMtlSyntaxToLocalOps", "1.6.1") def toLocalOps[F[_], A](
-      fa: F[A]): LocalOps[F, A] = catsMtlSyntaxToLocalOps(fa)
+  @deprecated("use catsMtlSyntaxToLocalOps", "1.7.0")
+  def toLocalOps[F[_], A](fa: F[A]): LocalOps[F, A] = catsMtlSyntaxToLocalOps(fa)
 }
 
 final class LocalOps[F[_], A](val fa: F[A]) extends AnyVal {

--- a/core/src/main/scala/cats/mtl/syntax/raise.scala
+++ b/core/src/main/scala/cats/mtl/syntax/raise.scala
@@ -21,7 +21,8 @@ package syntax
 trait RaiseSyntax {
   implicit def catsMtlSyntaxToRaiseOps[E](e: E): RaiseOps[E] = new RaiseOps(e)
 
-  @deprecated("use catsMtlSyntaxToRaiseOps", "1.6.1") def toRaiseOps[E](e: E): RaiseOps[E] =
+  @deprecated("use catsMtlSyntaxToRaiseOps", "1.7.0")
+  def toRaiseOps[E](e: E): RaiseOps[E] =
     catsMtlSyntaxToRaiseOps(e)
 }
 

--- a/core/src/main/scala/cats/mtl/syntax/state.scala
+++ b/core/src/main/scala/cats/mtl/syntax/state.scala
@@ -22,10 +22,11 @@ trait StateSyntax {
   implicit def catsMtlSyntaxToSetOps[S](e: S): SetOps[S] = new SetOps(e)
   implicit def catsMtlSyntaxToModifyOps[S](f: S => S): ModifyOps[S] = new ModifyOps(f)
 
-  @deprecated("use catsMtlSyntaxToSetOps", "1.6.1") def toSetOps[S](e: S): SetOps[S] =
+  @deprecated("use catsMtlSyntaxToSetOps", "1.7.0")
+  def toSetOps[S](e: S): SetOps[S] =
     catsMtlSyntaxToSetOps(e)
-  @deprecated("use catsMtlSyntaxToModifyOps", "1.6.1") def toModifyOps[S](
-      f: S => S): ModifyOps[S] = catsMtlSyntaxToModifyOps(f)
+  @deprecated("use catsMtlSyntaxToModifyOps", "1.7.0")
+  def toModifyOps[S](f: S => S): ModifyOps[S] = catsMtlSyntaxToModifyOps(f)
 }
 
 final class SetOps[S](val s: S) extends AnyVal {

--- a/core/src/main/scala/cats/mtl/syntax/tell.scala
+++ b/core/src/main/scala/cats/mtl/syntax/tell.scala
@@ -22,10 +22,11 @@ trait TellSyntax {
   implicit def catsMtlSyntaxToTellOps[L](e: L): TellOps[L] = new TellOps(e)
   implicit def catsMtlSyntaxToTupleOps[L, A](t: (L, A)): TupleOps[L, A] = new TupleOps(t)
 
-  @deprecated("use catsMtlSyntaxToTellOps", "1.6.1") def toTellOps[L](e: L): TellOps[L] =
+  @deprecated("use catsMtlSyntaxToTellOps", "1.7.0")
+  def toTellOps[L](e: L): TellOps[L] =
     catsMtlSyntaxToTellOps(e)
-  @deprecated("use catsMtlSyntaxToTupleOps", "1.6.1") def toTupleOps[L, A](
-      t: (L, A)): TupleOps[L, A] = catsMtlSyntaxToTupleOps(t)
+  @deprecated("use catsMtlSyntaxToTupleOps", "1.7.0")
+  def toTupleOps[L, A](t: (L, A)): TupleOps[L, A] = catsMtlSyntaxToTupleOps(t)
 }
 
 final class TupleOps[L, A](val t: (L, A)) extends AnyVal {


### PR DESCRIPTION
I was trying to use the new [custom error types technique](https://typelevel.org/blog/2025/09/02/custom-error-types.html) with cats-mtl in a Skunk-using project and ran into an unfortunate name collision. AFAICT if you 
```scala
import cats.mtl.syntax.all._
import skunk._
```
you end up importing two `implicit def toTupleOps` methods, one from [`TwiddleCompat`](https://github.com/typelevel/twiddles/blob/7643941668140c5680ca443bc21588d4efa79d36/core/shared/src/main/scala-2/org/typelevel/twiddles/TwiddleCompat.scala#L48-L49) (via Twiddles, via [Skunk](https://github.com/typelevel/skunk/blob/d4a6022ecf78c1d363c495827f46e4afcc2bf8af/modules/core/shared/src/main/scala/package.scala#L122)) and one from [`TellSyntax` via cats-mtl](https://github.com/typelevel/cats-mtl/blob/a77b64646cea60e93af4637eb3b585c71984ecd4/core/src/main/scala/cats/mtl/syntax/tell.scala#L23). On Scala 2, they cancel each other out and you end up with errors like 
```
value *: is not a member of skunk.EmptyTuple
```
Of course, I could do `import cats.mtl.syntax.raise._` or even `import cats.mtl.syntax.all.{toTupleOps => _, _}`, but that's a little unfortunate when teaching the new technique generally. (And users who want to use `Tell` with Twiddles have to figure out that they need to do something like `import cats.mtl.syntax.all.{toTupleOps => catsMtlSyntaxToTupleOps, _}`, which is not easily discoverable at all.)

This PR binary-compatibility renames the implicits using the naming pattern established in Cats, which should make it unlikely that these implicit methods will clash with the implicits from other libraries.